### PR TITLE
feat: register scholar-deep-research plugin in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -76,6 +76,16 @@
             "repository": "https://github.com/Agents365-ai/paper-fetch",
             "license": "MIT",
             "keywords": ["paper", "pdf", "doi", "open-access", "download", "unpaywall", "arxiv", "biorxiv", "pubmed", "research"]
+        },
+        {
+            "name": "scholar-deep-research",
+            "source": "./plugins/scholar-deep-research",
+            "description": "End-to-end academic research pipeline — 8-phase (Phase 0..7) script-driven workflow across 7 federated sources (OpenAlex, arXiv, Crossref, PubMed, DBLP, bioRxiv, Exa), cross-source dedup, transparent ranking, dual-backend citation chasing (OpenAlex + Semantic Scholar), parallel deep-read fan-out, mandatory self-critique, and cited reports across 5 archetypes",
+            "version": "0.10.0",
+            "author": { "name": "Agents365-ai" },
+            "repository": "https://github.com/Agents365-ai/scholar-deep-research",
+            "license": "MIT",
+            "keywords": ["literature-review", "research", "academic", "papers", "citations", "survey", "deep-research", "openalex", "arxiv", "pubmed", "crossref", "biorxiv", "dblp", "systematic-review", "bibtex"]
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds the `scholar-deep-research` entry to `plugins[]` in `marketplace.json`
- The plugin payload already lives at `plugins/scholar-deep-research/skills/scholar-deep-research/` — this PR just makes it discoverable
- After merge, `/plugin install scholar-deep-research` will work and the upstream sync workflow at [Agents365-ai/scholar-deep-research](https://github.com/Agents365-ai/scholar-deep-research) can keep the `version` field in lockstep with `SKILL.md` frontmatter

## Plugin metadata

| Field | Value |
|---|---|
| name | `scholar-deep-research` |
| version | `0.10.0` (sourced from SKILL.md frontmatter) |
| source repo | https://github.com/Agents365-ai/scholar-deep-research |
| license | MIT |

## Test plan

- [x] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` — valid JSON
- [ ] After merge: `/plugin marketplace add Agents365-ai/365-skills` followed by `/plugin install scholar-deep-research` should resolve
- [ ] After merge: a push to `Agents365-ai/scholar-deep-research:main` under `skills/scholar-deep-research/**` should trigger the source repo's `sync-365-skills.yml`, which mirrors files into `plugins/scholar-deep-research/skills/scholar-deep-research/` and bumps the `version` field here