### PR TITLE
feat: register target-prioritization plugin (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,6 +106,16 @@
             "repository": "https://github.com/Agents365-ai/journal-abbrev",
             "license": "MIT",
             "keywords": ["journal", "abbreviation", "iso4", "medline", "bibtex", "jabref", "citation", "academic", "research"]
+        },
+        {
+            "name": "target-prioritization",
+            "source": "./plugins/target-prioritization",
+            "description": "Multi-source drug-target due-diligence — turn a ranked gene list (e.g. scRNA-seq DE output) into a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan, then re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic: configurable focus disease and cell-context queries.",
+            "version": "0.1.0",
+            "author": { "name": "Agents365-ai" },
+            "repository": "https://github.com/Agents365-ai/target-prioritization",
+            "license": "PolyForm-NC-1.0.0",
+            "keywords": ["drug-discovery", "target-prioritization", "scrna-seq", "single-cell", "opentargets", "uniprot", "pubmed", "differential-expression"]
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Adds a new entry to `marketplace.json` for [Agents365-ai/target-prioritization](https://github.com/Agents365-ai/target-prioritization).
- Plugin name: `target-prioritization`, version `0.1.0`, license `PolyForm-NC-1.0.0`.
- Source repo's `.github/workflows/sync-365-skills.yml` will start populating `plugins/target-prioritization/` on its next push to main; this PR only registers the entry so the marketplace picks it up.

## What this plugin does
Multi-source drug-target due-diligence: take a ranked gene list (e.g. scRNA-seq DE output) and produce a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan; re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic with one-line retargeting for oncology / neurodegen / metabolic / etc.

## Test plan
- [ ] After merge, run \`/plugin install target-prioritization\` in a fresh Claude Code session.
- [ ] Confirm the source repo's first push triggers \`sync-365-skills.yml\` to populate \`plugins/target-prioritization/skills/target-prioritization/\`.