### PR TITLE
feat: register video-podcast-maker plugin (v2.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -126,6 +126,16 @@
             "repository": "https://github.com/Agents365-ai/pi-plugin-cc",
             "license": "Apache-2.0",
             "keywords": ["pi", "coding-agent", "code-review", "adversarial-review", "claude-code-plugin", "rescue", "background-tasks", "model-agnostic"]
+        },
+        {
+            "name": "video-podcast-maker",
+            "source": "./plugins/video-podcast-maker",
+            "description": "Automated topic-driven video podcast creation — research → script → TTS (7 backends: Edge / Azure / Doubao / CosyVoice / ElevenLabs / Google / OpenAI) → 4K Remotion render → BGM mix → Remotion-native subtitles. Multi-platform: Bilibili / YouTube / Xiaohongshu / Douyin / WeChat Channels. Outputs horizontal long-form (16:9 3840x2160) and vertical shorts (9:16 2160x3840). 15-step workflow with mandatory Studio preview, agent-native JSON envelope CLI, and per-video isolation via --public-dir.",
+            "version": "2.3.0",
+            "author": { "name": "Agents365-ai" },
+            "repository": "https://github.com/Agents365-ai/video-podcast-maker",
+            "license": "MIT",
+            "keywords": ["video", "podcast", "remotion", "tts", "bilibili", "youtube", "xiaohongshu", "douyin", "wechat-channels", "4k", "knowledge-video", "subtitles", "azure-speech", "edge-tts", "elevenlabs"]
         }
     ]
 }


### PR DESCRIPTION
## Summary
Registers the **video-podcast-maker** plugin in the marketplace so the upstream sync workflow can mirror its bundle into `plugins/video-podcast-maker/` and keep `version` in step with the source repo's `SKILL.md`.

## What the plugin does
Automated topic-driven video podcast creation — research → script → TTS → 4K Remotion render → BGM mix → Remotion-native subtitles. 15-step workflow, 7 TTS backends (Edge / Azure / Doubao / CosyVoice / ElevenLabs / Google / OpenAI), multi-platform output (Bilibili / YouTube / Xiaohongshu / Douyin / WeChat Channels), horizontal (16:9 3840×2160) + vertical shorts (9:16 2160×3840), agent-native JSON envelope CLI, mandatory Studio preview gate.

## How the bundle gets here
The upstream repo's [`.github/workflows/sync-365-skills.yml`](https://github.com/Agents365-ai/video-podcast-maker/blob/main/.github/workflows/sync-365-skills.yml) rsyncs `skills/video-podcast-maker/` into `plugins/video-podcast-maker/skills/video-podcast-maker/` on every push to main and updates the `version` field in this `marketplace.json` based on the YAML `version:` in `SKILL.md`.

Once this PR merges and the next push lands upstream, `plugins/video-podcast-maker/` will appear automatically. No manual sync needed.

## Source
- Repo: https://github.com/Agents365-ai/video-podcast-maker
- License: MIT
- Initial version: 2.3.0

## Test plan
- [ ] JSON validates (`python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"`)
- [ ] After merge: trigger a push (or `workflow_dispatch`) on the source repo's `sync-365-skills` workflow and confirm `plugins/video-podcast-maker/skills/video-podcast-maker/SKILL.md` materializes
- [ ] After sync: verify `version` field stays in step with SKILL.md