### PR TITLE
feat(marketplace): add bangumi-frames plugin entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -136,6 +136,16 @@
             "repository": "https://github.com/Agents365-ai/video-podcast-maker",
             "license": "MIT",
             "keywords": ["video", "podcast", "remotion", "tts", "bilibili", "youtube", "xiaohongshu", "douyin", "wechat-channels", "4k", "knowledge-video", "subtitles", "azure-speech", "edge-tts", "elevenlabs"]
+        },
+        {
+            "name": "bangumi-frames",
+            "source": "./plugins/bangumi-frames",
+            "description": "Bilibili anime frame & character organizer — download a bangumi/UP video (or local file), extract scene-change keyframes, split scenery vs character crops (anime person detection), then either cluster everyone by CCIP identity or pull ONE character out via a reference folder (one-vs-rest, distance-prefixed matches). Agent-native JSON envelope CLI with --dry-run, --schema, stable exit codes; optional OCR+LaMa subtitle/watermark removal.",
+            "version": "0.2.0",
+            "author": { "name": "Agents365-ai" },
+            "repository": "https://github.com/Agents365-ai/bangumi-frames",
+            "license": "MIT",
+            "keywords": ["bilibili", "anime", "bangumi", "frames", "screenshot", "character", "ccip", "video", "donghua"]
         }
     ]
 }


### PR DESCRIPTION
Registers the **bangumi-frames** skill in the marketplace — a Bilibili anime frame & character organizer (download → scene-cut keyframes → anime person detection → cluster everyone by CCIP identity *or* pull ONE character out via a reference folder). Agent-native JSON-envelope CLI (`--dry-run`, `--schema`, stable exit codes).

- Source repo: https://github.com/Agents365-ai/bangumi-frames (v0.2.0, MIT)
- Adds one entry to `.claude-plugin/marketplace.json` (`source: ./plugins/bangumi-frames`).
- The `Sync to 365-skills` workflow in the source repo will populate `plugins/bangumi-frames/skills/bangumi-frames/` on its next run (once the `SYNC_365_SKILLS_TOKEN` secret is set there) and keep the `version` field here bumped.