### PR TITLE
sync: agent-native-design v1.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -191,7 +191,7 @@
             "name": "agent-native-design",
             "source": "./plugins/agent-native-design",
             "description": "CLI design for AI agents — evaluate, design, and refactor CLIs so they reliably serve humans, AI agents, and orchestration systems simultaneously. Structured output, self-description, delegated auth, safety tiers, and a complete 8-phase interaction loop.",
-            "version": "1.3.5",
+            "version": "1.4.0",
             "author": { "name": "Agents365-ai" },
             "repository": "https://github.com/Agents365-ai/agent-native-design",
             "license": "MIT",

--- a/plugins/agent-native-design/skills/agent-native-design/SKILL.md
+++ b/plugins/agent-native-design/skills/agent-native-design/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agent-native-design
 description: Use when designing, reviewing, or refactoring a CLI that must serve AI agents alongside humans, or when converting an API or SDK into an agent-usable CLI interface.
-license: CC-BY-NC-4.0
+license: MIT
 homepage: https://github.com/Agents365-ai/agent-native-design
 compatibility: Includes sidecar metadata for OpenClaw, Hermes, pi-mono, and OpenAI Codex; the core SKILL.md is portable to any agent runtime that supports Agent Skills-style instructions.
 platforms: [macos, linux, windows]
-metadata: {"openclaw":{"requires":{},"emoji":"⌨️","os":["darwin","linux","win32"]},"hermes":{"tags":["cli","agent-native","interface-design","structured-output","schema-driven"],"category":"engineering","requires_tools":[],"related_skills":[]},"pimo":{"category":"engineering","tags":["cli","agent-native","interface-design","structured-output","schema-driven"]},"author":"Agents365-ai","version":"1.3.5"}
+metadata: {"openclaw":{"requires":{},"emoji":"⌨️","os":["darwin","linux","win32"]},"hermes":{"tags":["cli","agent-native","interface-design","structured-output","schema-driven"],"category":"engineering","requires_tools":[],"related_skills":[]},"pimo":{"category":"engineering","tags":["cli","agent-native","interface-design","structured-output","schema-driven"]},"author":"Agents365-ai","version":"1.4.0"}
 ---
 
 # agent-native-design
@@ -80,7 +80,7 @@ Channels: environment variables, exit codes, dry-run mode, stable command semant
 ### Foundational contract
 
 | Channel | Primary audience |
-|---------|-----------------|
+| --------- | ----------------- |
 | `stdout` | Machines and agents |
 | `stderr` | Humans |
 | `exit codes` | Systems and orchestrators |
@@ -92,7 +92,7 @@ This skill teaches how to make CLI a first-class interface for agents. Productio
 ## The complete interaction loop
 
 | Phase | Step | Description |
-|-------|------|-------------|
+| ------- | ------ | ------------- |
 | 0. Bootstrap | 1 | Human/system obtains auth token or credentials |
 | 0. Bootstrap | 2 | Set trusted env vars: token, profile, safety mode |
 | 1. Discovery | 3 | Agent loads skills or command summaries |
@@ -166,11 +166,13 @@ Check whether the CLI supports: bootstrap, discovery, parameter understanding, p
 
 Use the 14-criterion rubric to score the CLI. The full rubric lives in `references/rubric.md`. Every one of the seven principles has at least one rubric row backing it, so the score-to-principle mapping is total: P0 → Three-audience support, Non-interactive operation; P1 → Stdout contract, Stderr separation, Idempotent retries, Error recoverability; P2 → Trust boundary; P3 → Self-description (help), Dry-run; P4 → Safety tiers; P5 → Boundary validation; P6 → Schema introspection; P7 → Auth delegation. Then summarize per principle with evidence, risk, and recommendation. The full review checklists live in `references/checklists.md`.
 
+**Machine verification baseline.** When the CLI under review is installed and runnable, run `anc audit <command> --output json` (the [agentnative](https://github.com/brettdavies/agentnative) linter, 8 RFC 2119 principles) before applying the rubric. `anc` probes shipped-binary behavior: non-interactive operation, `--output json` validity, schema discoverability, help/version, exit codes, NO_COLOR, and dry-run. Score the rubric-only dimensions yourself — no current linter measures trust directionality (P2), boundary validation (P5), safety tiers (P4), auth delegation (P7), or schema version drift (P6). Use the rubric alone when the CLI is not installable or `anc` is unavailable; report the anc scorecard alongside the rubric score when it is.
+
 ### Step 5. Produce a refactor plan
 
-- **P0** must fix
-- **P1** should improve
-- **P2** long-term enhancements
+* **P0** must fix
+* **P1** should improve
+* **P2** long-term enhancements
 
 ---
 
@@ -222,7 +224,7 @@ Prioritized recommendations with examples drawn from `references/examples.md`.
 Load on demand — these are not in the agent's context until needed:
 
 | File | Read when |
-|------|-----------|
+| ------ | ----------- |
 | `references/examples.md` | Showing the user a good envelope, error, dry-run, batch response, or anti-pattern |
 | `references/rubric.md` | Producing the score component of a CLI review |
 | `references/checklists.md` | Walking through a CLI auditing list with the user, or sanity-checking a new design |

--- a/plugins/agent-native-design/skills/agent-native-design/references/citations.md
+++ b/plugins/agent-native-design/skills/agent-native-design/references/citations.md
@@ -4,27 +4,29 @@ Sources actually quoted or directly relied on in SKILL.md and the other referenc
 
 ## Anthropic engineering
 
-- *Code execution with MCP: Building more efficient agents* — https://www.anthropic.com/engineering/code-execution-with-mcp (Nov 4, 2025). Progressive disclosure of tool definitions; the 150K → 2K token reduction case study cited under Principle 3 / `design-patterns.md#help-design`.
-- *Beyond permission prompts: making Claude Code more secure and autonomous* — https://www.anthropic.com/engineering/claude-code-sandboxing (Oct 20, 2025). Approval fatigue and the 84% prompt-reduction figure cited under Principle 4 / `design-patterns.md#safety-design`.
+- *Code execution with MCP: Building more efficient agents* — <https://www.anthropic.com/engineering/code-execution-with-mcp> (Nov 4, 2025). Progressive disclosure of tool definitions; the 150K → 2K token reduction case study cited under Principle 3 / `design-patterns.md#help-design`.
+- *Beyond permission prompts: making Claude Code more secure and autonomous* — <https://www.anthropic.com/engineering/claude-code-sandboxing> (Oct 20, 2025). Approval fatigue and the 84% prompt-reduction figure cited under Principle 4 / `design-patterns.md#safety-design`.
 
 ## CLI-for-agents writing
 
-- Ugo Enyioha, *Writing CLI Tools That AI Agents Actually Want to Use* — https://dev.to/uenyioha/writing-cli-tools-that-ai-agents-actually-want-to-use-39no (Feb 27, 2025). Idempotency-on-retry and "agents cannot type 'y'" framings cited in the Idempotency and Non-interactive sections of `design-patterns.md`.
-- Thibault Le Ouay Ducasse / openstatus, *Building a CLI That Works for Humans and Machines* — https://www.openstatus.dev/blog/building-cli-for-human-and-agents (Apr 2, 2026). TTY detection as the human/machine switch cited under Principle 1.
-- Mario Zechner, *MCP vs CLI: Benchmarking Tools for Coding Agents* — https://mariozechner.at/posts/2025-08-15-mcp-vs-cli/ (Aug 15, 2025). Empirical case that many MCP servers could be CLI invocations.
-- Armin Ronacher, *Skills vs Dynamic MCP Loadouts* — https://lucumr.pocoo.org/2025/12/13/skills-vs-mcp/ (Dec 13, 2025). Schema/API stability as a first-class concern cited under Principle 6.
+- Ugo Enyioha, *Writing CLI Tools That AI Agents Actually Want to Use* — <https://dev.to/uenyioha/writing-cli-tools-that-ai-agents-actually-want-to-use-39no> (Feb 27, 2025). Idempotency-on-retry and "agents cannot type 'y'" framings cited in the Idempotency and Non-interactive sections of `design-patterns.md`.
+- Cloudflare, *The CLI for all of Cloudflare* — <https://blog.cloudflare.com/cf-cli-local-explorer/> (Apr 13, 2026). Schema-first generation of the CLI, SDKs, Terraform provider, and MCP server from one TypeScript source; ~3,000 API operations served in under 1,000 tokens; naming rules enforced mechanically at the schema layer ("always `--json`, never `--format=json`"). Independent industrial corroboration of the token-efficiency numbers in `hybrid-mcp-cli.md` and of Principle 6's schema-as-source-of-truth.
+- brettdavies, *agentnative: The Agent-Native CLI Standard* — <https://github.com/brettdavies/agentnative> (Apr 2026). Eight RFC 2119 principles plus the `anc` linter used as the machine verification baseline in the Standard review workflow (Step 4 of SKILL.md).
+- Thibault Le Ouay Ducasse / openstatus, *Building a CLI That Works for Humans and Machines* — <https://www.openstatus.dev/blog/building-cli-for-human-and-agents> (Apr 2, 2026). TTY detection as the human/machine switch cited under Principle 1.
+- Mario Zechner, *MCP vs CLI: Benchmarking Tools for Coding Agents* — <https://mariozechner.at/posts/2025-08-15-mcp-vs-cli/> (Aug 15, 2025). Empirical case that many MCP servers could be CLI invocations.
+- Armin Ronacher, *Skills vs Dynamic MCP Loadouts* — <https://lucumr.pocoo.org/2025/12/13/skills-vs-mcp/> (Dec 13, 2025). Schema/API stability as a first-class concern cited under Principle 6.
 
 ## CLI-vs-MCP benchmarks (2026)
 
-- Jannik Reinhard, *CLI Tools vs MCP: Better AI Agents With Less Context* — https://jannikreinhard.com/2026/02/22/why-cli-tools-are-beating-mcp-for-ai-agents/ (Feb 22, 2026). Source for the 28% / 33% / 55K / 35× numbers in `hybrid-mcp-cli.md`.
-- Manveer Chawla, *MCP vs. CLI for AI agents: When to Use Each (A Practical Decision Framework for 2026)* — https://manveerc.substack.com/p/mcp-vs-cli-ai-agents (Mar 8, 2026). Per-integration decision framework; production examples (Claude Code, Cowork) using both transports.
-- Soumyadeb Mitra / RudderStack, *CLI or MCP or both? The design pattern for AI agents managing your data stack* — https://www.rudderstack.com/blog/ai-agents-cli-mcp-design-pattern/ (Mar 18, 2026). The "writes via CLI, reads via MCP" split underpinning `hybrid-mcp-cli.md`.
+- Jannik Reinhard, *CLI Tools vs MCP: Better AI Agents With Less Context* — <https://jannikreinhard.com/2026/02/22/why-cli-tools-are-beating-mcp-for-ai-agents/> (Feb 22, 2026). Source for the 28% / 33% / 55K / 35× numbers in `hybrid-mcp-cli.md`.
+- Manveer Chawla, *MCP vs. CLI for AI agents: When to Use Each (A Practical Decision Framework for 2026)* — <https://manveerc.substack.com/p/mcp-vs-cli-ai-agents> (Mar 8, 2026). Per-integration decision framework; production examples (Claude Code, Cowork) using both transports.
+- Soumyadeb Mitra / RudderStack, *CLI or MCP or both? The design pattern for AI agents managing your data stack* — <https://www.rudderstack.com/blog/ai-agents-cli-mcp-design-pattern/> (Mar 18, 2026). The "writes via CLI, reads via MCP" split underpinning `hybrid-mcp-cli.md`.
 
 ## Pre-agent baseline
 
-- *Scripting with GitHub CLI* — https://github.blog/engineering/engineering-principles/scripting-with-github-cli/ (Mar 11, 2021). `gh api --jq` and structured JSON output as a first-class CLI pattern. The post predates the `gh <resource> --json field1,field2` field-selection flag (cli/cli#1089) but lays out the design philosophy that flag is built on.
-- *Command Line Interface Guidelines* — https://clig.dev/. The pre-agent baseline for human-first CLI design. This skill extends it; it does not replace it.
-- `sysexits.h` — https://manpages.ubuntu.com/manpages/noble/man3/sysexits.h.3head.html. The BSD exit-code vocabulary that `design-patterns.md#exit-code-model` deliberately simplifies away from.
+- *Scripting with GitHub CLI* — <https://github.blog/engineering/engineering-principles/scripting-with-github-cli/> (Mar 11, 2021). `gh api --jq` and structured JSON output as a first-class CLI pattern. The post predates the `gh <resource> --json field1,field2` field-selection flag (cli/cli#1089) but lays out the design philosophy that flag is built on.
+- *Command Line Interface Guidelines* — <https://clig.dev/>. The pre-agent baseline for human-first CLI design. This skill extends it; it does not replace it.
+- `sysexits.h` — <https://manpages.ubuntu.com/manpages/noble/man3/sysexits.h.3head.html>. The BSD exit-code vocabulary that `design-patterns.md#exit-code-model` deliberately simplifies away from.
 
 ---
 

--- a/plugins/agent-native-design/skills/agent-native-design/scripts/validate-metadata.sh
+++ b/plugins/agent-native-design/skills/agent-native-design/scripts/validate-metadata.sh
@@ -21,8 +21,6 @@ assert_contains docs/install_CN.md 'skills/agent-native-design ~/.codex/skills/'
 assert_contains docs/install_CN.md 'skills/agent-native-design .codex/skills/'
 
 assert_contains skills/agent-native-design/SKILL.md 'Includes sidecar metadata for OpenClaw, Hermes, pi-mono, and OpenAI Codex'
-assert_contains README.md 'includes metadata for the platforms listed below'
-assert_contains README_CN.md '并为下列平台提供元数据'
 
 assert_contains skills/agent-native-design/SKILL.md 'Use the 14-criterion rubric to score the CLI.'
 assert_contains skills/agent-native-design/SKILL.md 'Report the 14-criterion rubric score first'
@@ -47,7 +45,7 @@ verify_frontmatter_version_against_tag() {
   local latest_tag
   latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)
   if [ -z "$latest_tag" ]; then
-    return 0  # no tags reachable; nothing to compare against (e.g. shallow clone)
+    return 0 # no tags reachable; nothing to compare against (e.g. shallow clone)
   fi
   local tag_version="${latest_tag#v}"
 


### PR DESCRIPTION
Manual sync of v1.4.0 content because the `Sync to 365-skills` workflow failed with `Bad credentials` (expired `SYNC_365_SKILLS_TOKEN` secret — needs a refreshed fine-grained PAT with Contents: write on this repo).

Mirrors the workflow's normal behavior: nested skill copy updated to v1.4.0 (anc baseline, new citations, MIT license) and marketplace.json version bumped.