### PR TITLE
sync mermaid-skill 1.3.0 from source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
             "name": "mermaid",
             "source": "./plugins/mermaid",
             "description": "Mermaid diagrams — text-based charts with auto-layout, GitHub-native rendering, and CLI export to PNG/SVG/PDF",
-            "version": "1.0.0",
+            "version": "1.3.0",
             "author": { "name": "Agents365-ai" },
             "repository": "https://github.com/Agents365-ai/mermaid-skill",
             "license": "MIT",

--- a/plugins/mermaid/skills/mermaid-skill/SKILL.md
+++ b/plugins/mermaid/skills/mermaid-skill/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: creating-mermaid-diagrams
-description: Generate Mermaid diagrams (.mmd) and export to PNG/SVG/PDF using mmdc CLI or Kroki API. USE THIS SKILL when user mentions diagram, flowchart, sequence diagram, class diagram, ER diagram, state machine, architecture, visualize, git graph, 画图, 架构图, 流程图, 时序图. PROACTIVELY USE when explaining ANY system with 3+ components, API flows, authentication sequences, class hierarchies, database schemas, or state machines. Supports 11+ diagram types with fully automatic layout.
+name: mermaid-skill
+description: Generate Mermaid diagrams (.mmd) and export to PNG/SVG/PDF using mmdc CLI or Kroki API. USE THIS SKILL when user mentions diagram, flowchart, sequence diagram, class diagram, ER diagram, state machine, architecture, visualize, git graph, 画图, 架构图, 流程图, 时序图, 类图, ER图, 甘特图, 状态机. PROACTIVELY USE when explaining ANY system with 3+ components, API flows, authentication sequences, class hierarchies, database schemas, or state machines. Supports 17+ diagram types with fully automatic layout.
 homepage: https://github.com/Agents365-ai/creating-mermaid-diagrams
-metadata: {"openclaw":{"requires":{"bins":["curl"]},"emoji":"📊"}}
+version: 1.3.0
 ---
 
 # Mermaid Diagrams
@@ -11,66 +11,137 @@ Generate `.mmd` text files and export to PNG/SVG/PDF using `mmdc` (local) or Kro
 
 **Key advantage:** Text-based syntax with **fully automatic layout** — no x/y coordinates needed.
 
+## When to use / when NOT to use
+
+**Use this skill for:** diagrams-as-code with automatic layout (flowchart, sequence, class, state, ER, gantt, mindmap, architecture) — text source that lives in git and embeds in Markdown.
+
+**Do NOT use it — route elsewhere — for:**
+
+- Pixel-precise placement, custom layout, branded icons, or heavy styling → **drawio**.
+- A hand-drawn / sketchy aesthetic → **excalidraw** or **tldraw**.
+- A freeform whiteboard or freehand strokes → **tldraw**.
+- Strict, conventional UML notation → **plantuml**.
+
 ## Prerequisites
 
-**Option A: Local (mmdc)**
+**Option A: Local (mmdc)** — also needs a headless Chrome (mmdc renders via Puppeteer)
+
 ```bash
 npm install -g @mermaid-js/mermaid-cli
+npx puppeteer browsers install chrome-headless-shell   # required — mmdc has no bundled browser
 mmdc --version
 ```
 
+> `mmdc --version` succeeds even with **no** Chrome installed, but every export then fails with `Could not find Chrome`. Install the browser above (or set `PUPPETEER_EXECUTABLE_PATH` to a system Chrome). If you can't, use Kroki (Option B) — it needs no browser.
+
+**CI / Docker:** mmdc crashes with `Running as root without --no-sandbox` in containers. Pass the bundled puppeteer config (see `scripts/puppeteer-config.json`):
+
+```bash
+mmdc -p scripts/puppeteer-config.json -i diagram.mmd -o diagram.png
+```
+
 **Option B: Kroki API (no install)**
+
 ```bash
 curl --version  # Just need curl
 ```
 
 ## Workflow
 
-0. **Update check (notify, don't pull)** — first use per conversation. Throttle to once per 24 h via `<this-skill-dir>/.last_update`; never mutate the skill directory without explicit user consent.
-
-   - If `.last_update` exists and is <24 h old, skip this step entirely.
-   - Otherwise, fetch the latest tag from upstream:
-     ```bash
-     git -C <this-skill-dir> ls-remote --tags origin 'v*' 2>/dev/null \
-       | awk '{print $2}' | sed 's|refs/tags/||' | sort -V | tail -1
-     ```
-   - Compare with this skill's `metadata.version` from the frontmatter. If the upstream tag is strictly newer (semver), tell the user one line and ask:
-     > "A newer version of this skill is available: vX.Y.Z → vA.B.C. Want me to `git pull`?"
-
-     If they say yes, run `git -C <this-skill-dir> pull --ff-only`. Refresh `.last_update` either way so the prompt doesn't repeat for 24 hours.
-   - If upstream is the same or older, refresh `.last_update` silently and continue.
-   - On any failure (offline, not a git checkout — e.g. ClawHub-installed copy, read-only path, no permission), swallow the error silently and continue with the user's task. Do not mention the failure.
-1. **Check deps** — try `mmdc --version`, fallback to Kroki if unavailable
+1. **Check deps** — validate via Kroki (needs only `curl`); check `mmdc --version` and a headless Chrome only when local export (PNG quality / PDF) is wanted
 2. **Pick diagram type** — choose from table below
 3. **Generate** — write `.mmd` file to disk
-4. **Validate** — run validation (REQUIRED before export)
+4. **Validate** — Kroki-first (see Validation; REQUIRED before export)
 5. **Export** — use `mmdc` or Kroki API to produce PNG/SVG/PDF
-6. **Report** — tell user the output file paths
+6. **Self-check (vision)** — read the exported PNG and fix readability/layout defects that automatic layout can't prevent (clipped labels, cramped density, wrong orientation), then re-validate + re-export. Max 2 rounds; skip if no vision. See **Self-Check (vision)** below.
+7. **Review loop** — show the image to the user, apply the minimal `.mmd` edit per request, re-export until approved (5-round safety valve). See **Review Loop** below.
+8. **Report** — tell user the output file paths
 
 ## Validation (Required)
 
 **NEVER export a diagram without validating first.**
 
-```bash
-# Validate with mmdc (local)
-mmdc -i diagram.mmd -o /tmp/test.png 2>&1
+Prefer **Kroki** for validation — it needs no browser and sidesteps the `Could not find Chrome` trap entirely. Use `mmdc` for validation only when offline.
 
-# Validate with Kroki (if mmdc unavailable)
+```bash
+# Validate with Kroki (preferred — no browser needed)
 curl -s -X POST -H "Content-Type: text/plain" --data-binary @diagram.mmd https://kroki.io/mermaid/svg -o /tmp/test.svg && echo "Valid" || echo "Invalid"
+
+# Validate with mmdc (offline fallback — requires headless Chrome)
+mmdc -i diagram.mmd -o /tmp/test.svg 2>&1
 
 # If error, fix the .mmd file and validate again
 # Only proceed to export after validation passes
 ```
 
 Common validation errors:
+
 - Missing quotes around labels with special characters
 - Wrong arrow syntax (use `->>` for sequence, `-->` for flowchart)
 - Undeclared participants in sequence diagrams
 
+> A `Could not find Chrome` (or puppeteer) error from `mmdc` is a **setup** problem, not a diagram error — the `.mmd` may be perfectly valid. Validate via Kroki instead of "fixing" correct syntax.
+
+## Self-Check (vision)
+
+**Zero-cost pre-check:** before spending a vision call, read the PNG dimensions (`sips -g pixelWidth -g pixelHeight diagram.png` on macOS, `file diagram.png` elsewhere). An extreme aspect ratio (longer side > 8x the shorter) is a "wrong orientation" defect — fix it without vision.
+
+Validation (above) only proves the syntax is legal — it says nothing about whether the **rendered** diagram is readable. After exporting, use the agent's vision capability to read the PNG and catch what automatic layout can't prevent. Mermaid positions everything itself, so the failures here are about content and readability, **not** overlaps:
+
+| Check | What to look for | Fix |
+| --- | --- | --- |
+| Label truncation | Node / edge text clipped or cut off | Shorten the label, or wrap it with `<br/>` |
+| Cramped, unreadable density | Too many nodes crammed together; tangled lines | Flip direction (`TD`↔`LR`), split into `subgraph`s, or reduce nodes |
+| Wrong orientation / aspect | Diagram far too wide or too tall to read | Change `flowchart TD`↔`LR` (or set `direction` in class/state) |
+| Edge spaghetti | Many edges crossing, hard to follow | Reorder node declarations so connected nodes sit adjacent; group with `subgraph` |
+| Wrong diagram type | Type doesn't suit the content (e.g. flowchart for a timeline) | Switch type (`gantt`, `sequenceDiagram`, `stateDiagram-v2`, …) |
+| Low contrast | Text blends into the node fill | Adjust `classDef` / theme so text contrasts the fill |
+
+- Max **2 self-check rounds** — if issues remain after 2 fixes, show the user anyway.
+- **Re-validate (syntax) and re-export after every fix.**
+- If vision is unavailable, skip self-check and show the PNG directly.
+
+## Review Loop
+
+After self-check, show the exported image and collect feedback. Apply the **minimal `.mmd` edit** for each request, then re-validate and re-export:
+
+| User request | Edit action |
+| --- | --- |
+| Change a label | Edit the node / edge text in the `.mmd` |
+| Add / remove a node or edge | Add or delete the matching line |
+| Change a color | Add / adjust a `classDef` and `class <node> <className>` |
+| Change layout direction | Swap `TD`↔`LR` (flowchart) or set `direction` (class / state) |
+| Restructure / group | Wrap related nodes in a `subgraph`, or regenerate |
+
+- Overwrite the same `diagram.mmd` / `diagram.png` each round — don't create `v1`, `v2`, …
+- **Safety valve:** after 5 rounds, generate a mermaid.live handoff link (see next section) so the user fine-tunes the current diagram in the browser.
+
+## Mermaid.live Handoff
+
+When the review loop ends (approved or safety-valve), generate a one-click link that opens the current `.mmd` in the [mermaid.live](https://mermaid.live) editor for interactive fine-tuning:
+
+```bash
+python3 scripts/mermaid_live_link.py diagram.mmd
+# -> https://mermaid.live/edit#pako:...
+```
+
+Pure `zlib` + `base64` (raw-deflate + URL-safe base64, same encoding mermaid.live uses), works offline. The script self-verifies with a round-trip decode before printing.
+
+## Batch Mode (Repo Survey)
+
+When the user asks to diagram a whole repo ("survey this codebase", "map the architecture"):
+
+1. **Scan** — locate schemas (SQL / ORM models), API routes, and state machines / lifecycle enums in the codebase
+2. **Propose** — one diagram per finding: ER for the schema, sequence for a main API flow, state for a lifecycle, flowchart for overall service layout; confirm the set with the user before generating
+3. **Generate + export** — run the standard workflow per diagram into one output folder
+4. **Overview page** — inline every exported SVG into a single self-contained `index.html` (title + one section per diagram, no CDN), so the user opens one file
+
+Same validation and self-check rules apply to every diagram in the batch.
+
 ## Diagram Types
 
 | Type | Keyword | Use for |
-|------|---------|---------|
+| ------ | --------- | --------- |
 | Flowchart | `flowchart TD/LR` | processes, pipelines, decisions |
 | Sequence | `sequenceDiagram` | API calls, message passing |
 | Class | `classDiagram` | OOP models, data structures |
@@ -79,103 +150,29 @@ Common validation errors:
 | Gantt | `gantt` | project timelines |
 | Pie | `pie` | proportions |
 | Git Graph | `gitGraph` | branch strategies |
-| C4 Context | `C4Context` | high-level architecture |
+| C4 Context | `C4Context` | high-level system context |
+| Architecture | `architecture-beta` | cloud / CI/CD service layouts |
 | Mind Map | `mindmap` | topic breakdowns |
+| User Journey | `journey` | user-experience flows |
+| Use Case | `usecase-beta` | actor–system interactions (UML) |
+| Cynefin | `cynefin-beta` | sense-making / complexity domains |
+| Event Modeling | `eventmodeling` | event-driven system timelines |
+| Tree View | `treeView-beta` | file / directory hierarchies |
+| Wardley Maps | `wardley-beta` | business strategy / value chains |
 
 ## Syntax Reference
 
 **Flowchart**: See [reference/FLOWCHART.md](reference/FLOWCHART.md)
 **Sequence**: See [reference/SEQUENCE.md](reference/SEQUENCE.md)
 **Class & ER**: See [reference/CLASS-ER.md](reference/CLASS-ER.md)
+**Architecture**: See [reference/ARCHITECTURE.md](reference/ARCHITECTURE.md)
+**Use Case**: See [reference/USECASE.md](reference/USECASE.md)
 **Other types**: See [reference/OTHER-TYPES.md](reference/OTHER-TYPES.md)
+**Themes & styling**: See [reference/THEMES.md](reference/THEMES.md)
 
 ## Examples
 
-### Example 1: API Authentication Flow
-
-**User prompt:**
-> Create a sequence diagram for JWT authentication
-
-**Generated `.mmd`:**
-```mermaid
-sequenceDiagram
-  participant C as Client
-  participant G as API Gateway
-  participant A as Auth Service
-  participant D as Database
-
-  C->>G: POST /login {email, password}
-  G->>A: validate(credentials)
-  A->>D: SELECT user WHERE email=?
-  D-->>A: user record
-  A-->>A: verify password hash
-  A-->>G: 200 OK + JWT token
-  G-->>C: {token: "eyJhbG..."}
-```
-
-**Output files:** `auth-flow.mmd` + `auth-flow.png`
-
----
-
-### Example 2: Microservices Architecture
-
-**User prompt:**
-> Draw an e-commerce microservices architecture
-
-**Generated `.mmd`:**
-```mermaid
-flowchart TD
-  subgraph Clients
-    M[Mobile App]
-    W[Web App]
-  end
-
-  GW[API Gateway]
-
-  subgraph Services
-    US[User Service]
-    OS[Order Service]
-    PS[Product Service]
-    PAY[Payment Service]
-  end
-
-  subgraph Data
-    UDB[(User DB)]
-    ODB[(Order DB)]
-    PDB[(Product DB)]
-    REDIS[(Redis Cache)]
-  end
-
-  M & W --> GW
-  GW --> US & OS & PS & PAY
-  US --> UDB
-  OS --> ODB
-  PS --> PDB
-  PAY --> REDIS
-```
-
-**Output files:** `ecommerce-arch.mmd` + `ecommerce-arch.png`
-
----
-
-### Example 3: Order State Machine
-
-**User prompt:**
-> Show order lifecycle states
-
-**Generated `.mmd`:**
-```mermaid
-stateDiagram-v2
-  [*] --> Pending : order created
-  Pending --> Confirmed : payment success
-  Pending --> Cancelled : timeout/cancel
-  Confirmed --> Shipped : dispatched
-  Shipped --> Delivered : received
-  Delivered --> [*]
-  Cancelled --> [*]
-```
-
-**Output files:** `order-states.mmd` + `order-states.png`
+See [reference/EXAMPLES.md](reference/EXAMPLES.md) for four worked examples (JWT auth sequence, microservices architecture, order state machine, cloud architecture) — each with the user prompt, the generated `.mmd`, and the output files.
 
 ## Export Commands
 
@@ -187,7 +184,8 @@ Requires `mmdc` installed locally. Best for offline use.
 # PNG (recommended: 2048px wide, white background)
 mmdc -i diagram.mmd -o diagram.png -w 2048 --backgroundColor white
 
-# PNG with theme (default | dark | neutral | forest | base)
+# PNG with theme — valid -t values: default | dark | neutral | forest
+# (`base` is NOT a valid -t value; it only works inside a %%{init: {'theme':'base'}}%% directive)
 mmdc -i diagram.mmd -o diagram.png -w 2048 --backgroundColor white --theme neutral
 
 # SVG
@@ -208,16 +206,19 @@ curl -X POST -H "Content-Type: text/plain" --data-binary @diagram.mmd https://kr
 # PNG via Kroki
 curl -X POST -H "Content-Type: text/plain" --data-binary @diagram.mmd https://kroki.io/mermaid/png -o diagram.png
 
-# PDF via Kroki
-curl -X POST -H "Content-Type: text/plain" --data-binary @diagram.mmd https://kroki.io/mermaid/pdf -o diagram.pdf
+# PDF is NOT supported by Kroki for Mermaid — POSTing to /mermaid/pdf returns
+# HTTP 400 ("Unsupported output format: pdf for mermaid. Must be one of png or svg").
+# For PDF, use the local mmdc path instead:  mmdc -i diagram.mmd -o diagram.pdf
 ```
 
 **Kroki advantages:**
+
 - No local installation required
 - Works on any system with `curl`
 - Supports 20+ diagram types (PlantUML, GraphViz, D2, etc.)
 
 **When to use Kroki:**
+
 - `mmdc` installation fails
 - Quick one-off diagrams
 - CI/CD pipelines without Node.js
@@ -225,8 +226,11 @@ curl -X POST -H "Content-Type: text/plain" --data-binary @diagram.mmd https://kr
 ## Common Mistakes
 
 | Mistake | Fix |
-|---------|-----|
+| --------- | ----- |
 | `mmdc` not found | `npm install -g @mermaid-js/mermaid-cli` |
+| `mmdc` error `Could not find Chrome` | Install the headless browser: `npx puppeteer browsers install chrome-headless-shell` (or use Kroki) |
+| Kroki PDF fails with HTTP 400 | Kroki does PNG/SVG only for Mermaid; use local `mmdc` for PDF |
+| Valid diagram reported "invalid" by `mmdc` | The error is a Chrome/puppeteer setup failure, not a syntax error — don't rewrite correct `.mmd`; fix the browser or validate via Kroki |
 | Wrong arrow in sequence | Use `->>` for request, `-->>` for response |
 | Special chars in label | Wrap in quotes: `A["Label: value"]` |
 | Blank/small output | Add `-w 2048` flag |

--- a/plugins/mermaid/skills/mermaid-skill/reference/ARCHITECTURE.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/ARCHITECTURE.md
@@ -1,0 +1,86 @@
+# Architecture Diagram Syntax
+
+Architecture diagrams use `architecture-beta` and are well suited for cloud and CI/CD service layouts.
+
+## Basic Structure
+
+```mermaid
+architecture-beta
+  group api(cloud)[API]
+
+  service gateway(internet)[Gateway] in api
+  service db(database)[Database] in api
+  service cache(disk)[Cache] in api
+
+  gateway:R --> L:db
+  gateway:B --> T:cache
+```
+
+## Building Blocks
+
+### Groups
+
+```text
+group {group id}({icon name})[{title}] (in {parent id})?
+```
+
+### Services
+
+```text
+service {service id}({icon name})[{title}] (in {parent id})?
+```
+
+### Junctions
+
+```text
+junction {junction id} (in {parent id})?
+```
+
+## Edges
+
+The edge syntax is:
+
+```text
+{serviceId}{{group}}?:{T|B|L|R} {<}?--{>}? {T|B|L|R}:{serviceId}{{group}}?
+```
+
+- Use `L`, `R`, `T`, or `B` to choose the side of each service.
+- Add `<` and/or `>` to point the arrow head in the desired direction.
+- Use the optional `{group}` modifier when connecting a service through its containing group.
+
+### Example
+
+```mermaid
+architecture-beta
+  group public_api(cloud)[Public API]
+  group private_api(cloud)[Private API] in public_api
+
+  service subnet(server)[Subnet] in private_api
+  service gateway(internet)[Gateway] in public_api
+
+  gateway:R --> L:subnet{group}
+```
+
+## Icons
+
+Default icons include `cloud`, `database`, `disk`, `internet`, and `server`.
+
+You can also use icon packs or custom icons by following Mermaid's icon registration configuration.
+
+### Example: AWS Icons
+
+```mermaid
+architecture-beta
+    group api(logos:aws-lambda)[API]
+
+    service db(logos:aws-aurora)[Database] in api
+    service disk1(logos:aws-glacier)[Storage] in api
+    service disk2(logos:aws-s3)[Storage] in api
+    service server(logos:aws-ec2)[Server] in api
+
+    db:L -- R:server
+    disk1:T -- B:server
+    disk2:T -- B:db
+```
+
+logos reference: <https://icon-sets.iconify.design/logos>

--- a/plugins/mermaid/skills/mermaid-skill/reference/CLASS-ER.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/CLASS-ER.md
@@ -28,7 +28,7 @@ classDiagram
 ### Visibility Modifiers
 
 | Symbol | Meaning |
-|--------|---------|
+| -------- | --------- |
 | `+` | Public |
 | `-` | Private |
 | `#` | Protected |
@@ -37,7 +37,7 @@ classDiagram
 ### Relationships
 
 | Syntax | Type | Meaning |
-|--------|------|---------|
+| -------- | ------ | --------- |
 | `<\|--` | Inheritance | extends |
 | `*--` | Composition | owns (lifecycle) |
 | `o--` | Aggregation | has (independent) |
@@ -55,7 +55,7 @@ classDiagram
 ```
 
 | Notation | Meaning |
-|----------|---------|
+| ---------- | --------- |
 | `1` | Exactly one |
 | `0..1` | Zero or one |
 | `*` | Many |
@@ -98,7 +98,7 @@ erDiagram
 ### Relationship Notation
 
 | Left | Right | Meaning |
-|------|-------|---------|
+| ------ | ------- | --------- |
 | `\|\|` | `\|\|` | One to one |
 | `\|\|` | `o{` | One to zero or many |
 | `\|\|` | `\|{` | One to one or many |

--- a/plugins/mermaid/skills/mermaid-skill/reference/EXAMPLES.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/EXAMPLES.md
@@ -1,0 +1,109 @@
+# Worked Examples
+
+Four complete prompt → `.mmd` → output walkthroughs. Copy the structure, not the content.
+
+## Example 1: API Authentication Flow
+
+**User prompt:**
+> Create a sequence diagram for JWT authentication
+
+**Generated `.mmd`:**
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant G as API Gateway
+  participant A as Auth Service
+  participant D as Database
+
+  C->>G: POST /login {email, password}
+  G->>A: validate(credentials)
+  A->>D: SELECT user WHERE email=?
+  D-->>A: user record
+  A-->>A: verify password hash
+  A-->>G: 200 OK + JWT token
+  G-->>C: {token: "eyJhbG..."}
+```
+
+**Output files:** `auth-flow.mmd` + `auth-flow.png`
+
+## Example 2: Microservices Architecture
+
+**User prompt:**
+> Draw an e-commerce microservices architecture
+
+**Generated `.mmd`:**
+
+```mermaid
+flowchart TD
+  subgraph Clients
+    M[Mobile App]
+    W[Web App]
+  end
+
+  GW[API Gateway]
+
+  subgraph Services
+    US[User Service]
+    OS[Order Service]
+    PS[Product Service]
+    PAY[Payment Service]
+  end
+
+  subgraph Data
+    UDB[(User DB)]
+    ODB[(Order DB)]
+    PDB[(Product DB)]
+    REDIS[(Redis Cache)]
+  end
+
+  M & W --> GW
+  GW --> US & OS & PS & PAY
+  US --> UDB
+  OS --> ODB
+  PS --> PDB
+  PAY --> REDIS
+```
+
+**Output files:** `ecommerce-arch.mmd` + `ecommerce-arch.png`
+
+## Example 3: Order State Machine
+
+**User prompt:**
+> Show order lifecycle states
+
+**Generated `.mmd`:**
+
+```mermaid
+stateDiagram-v2
+  [*] --> Pending : order created
+  Pending --> Confirmed : payment success
+  Pending --> Cancelled : timeout/cancel
+  Confirmed --> Shipped : dispatched
+  Shipped --> Delivered : received
+  Delivered --> [*]
+  Cancelled --> [*]
+```
+
+**Output files:** `order-states.mmd` + `order-states.png`
+
+## Example 4: Cloud Architecture
+
+**User prompt:**
+> Draw a simple service architecture for an API
+
+**Generated `.mmd`:**
+
+```mermaid
+architecture-beta
+  group api(cloud)[API]
+
+  service gateway(internet)[Gateway] in api
+  service db(database)[Database] in api
+  service cache(disk)[Cache] in api
+
+  gateway:R --> L:db
+  gateway:B --> T:cache
+```
+
+**Output files:** `api-architecture.mmd` + `api-architecture.png`

--- a/plugins/mermaid/skills/mermaid-skill/reference/FLOWCHART.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/FLOWCHART.md
@@ -19,7 +19,7 @@ flowchart TD
 ## Direction
 
 | Keyword | Direction |
-|---------|-----------|
+| --------- | ----------- |
 | `TD` / `TB` | Top to bottom |
 | `LR` | Left to right |
 | `RL` | Right to left |
@@ -28,7 +28,7 @@ flowchart TD
 ## Node Shapes
 
 | Syntax | Shape | Use for |
-|--------|-------|---------|
+| -------- | ------- | --------- |
 | `[text]` | Rectangle | Default nodes |
 | `(text)` | Rounded rectangle | Processes |
 | `{text}` | Diamond | Decisions |
@@ -37,11 +37,12 @@ flowchart TD
 | `((text))` | Circle | Start/end points |
 | `>text]` | Flag | Async events |
 | `{{text}}` | Hexagon | Preparation steps |
+| `A@{ shape: datastore, label: "DB" }` | Datastore (v11.15+) | Data persistence (top/bottom borders only) |
 
 ## Arrow Types
 
 | Syntax | Style | Use for |
-|--------|-------|---------|
+| -------- | ------- | --------- |
 | `-->` | Arrow | Normal flow |
 | `---` | Line | Connection (no direction) |
 | `-.->` | Dashed arrow | Optional/async |
@@ -79,6 +80,7 @@ flowchart TD
 ## Special Characters
 
 Wrap in quotes for special characters:
+
 ```mermaid
 flowchart LR
   A["Node: with colon"]

--- a/plugins/mermaid/skills/mermaid-skill/reference/OTHER-TYPES.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/OTHER-TYPES.md
@@ -119,3 +119,90 @@ C4Context
   Rel(user, system, "Uses")
   Rel(system, external, "Calls")
 ```
+
+---
+
+## Tree View Diagram
+
+Shows hierarchical / file-tree data with indentation (v11.14+, `treeView-beta`). Directories end with `/`; box-drawing input (`├──`, `└──`, `│`) is auto-detected (v11.16+).
+
+```mermaid
+treeView-beta
+  my-project/
+    src/
+      index.js
+    package.json
+    README.md
+```
+
+---
+
+## Event Modeling Diagram
+
+Describes information flow over time with swimlane time frames (`eventmodeling`, v11.15+). `tf` = compact, `timeframe` = relaxed. Relations are inferred by default.
+
+```mermaid
+eventmodeling
+  tf 01 ui CartUI
+  tf 02 cmd AddItem
+  tf 03 evt ItemAdded
+```
+
+Entity kinds: `ui` (UI), `cmd` (command), `evt` (event), plus view / automation / translation patterns. Each time frame needs a unique number.
+
+---
+
+## Cynefin Diagram
+
+Sense-making framework with five complexity domains (`cynefin-beta`, v11.16+): clear, complicated, complex, chaotic, confusion.
+
+```mermaid
+cynefin-beta
+  title Incident Response
+
+  complex
+    "Investigate root cause"
+    "Run chaos experiment"
+
+  complicated
+    "Analyze performance data"
+
+  clear
+    "Restart service"
+
+  chaotic
+    "Page on-call immediately"
+
+  confusion
+    "Unknown failure mode"
+
+  complex --> complicated : "Pattern identified"
+  clear --> chaotic : "Complacency"
+```
+
+Keep per-domain item lists short — the quadrants have fixed layout and long lists can overflow. The confusion ellipse caps at 3 items (+N more badge).
+
+---
+
+## Wardley Maps
+
+Business strategy maps positioning components on visibility (Y) × evolution (X) axes (`wardley-beta`, v11.14+).
+
+```mermaid
+wardley-beta
+  title Tea Shop Value Chain
+
+  anchor Business [0.95, 0.63]
+  component Cup of Tea [0.79, 0.61]
+  component Hot Water [0.52, 0.80]
+
+  Business -> Cup of Tea
+  Cup of Tea -> Hot Water
+
+  evolve Kettle 0.62
+```
+
+- Coordinates are `[visibility, evolution]` (0.0–1.0) — **not** (x, y)
+- `component Name [v, e]` — a component node; `anchor Name [v, e]` — user/customer node (bold)
+- `name -> name` — dependency link; `evolve Name 0.62` — mark evolution movement
+- Optional: `size [1100, 600]` canvas, `(inertia)` decorator for legacy components

--- a/plugins/mermaid/skills/mermaid-skill/reference/SEQUENCE.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/SEQUENCE.md
@@ -20,6 +20,7 @@ sequenceDiagram
 ## Participants
 
 Declare in desired left-to-right order:
+
 ```mermaid
 sequenceDiagram
   participant A as Alice
@@ -33,7 +34,7 @@ sequenceDiagram
 ## Arrow Types
 
 | Syntax | Style | Use for |
-|--------|-------|---------|
+| -------- | ------- | --------- |
 | `->>` | Solid arrow | Sync request |
 | `-->>` | Dashed arrow | Response |
 | `-x` | Solid with X | Async (fire & forget) |
@@ -52,6 +53,7 @@ sequenceDiagram
 ```
 
 Or explicit:
+
 ```mermaid
 sequenceDiagram
   C->>S: request

--- a/plugins/mermaid/skills/mermaid-skill/reference/THEMES.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/THEMES.md
@@ -1,0 +1,41 @@
+# Theme & Styling Presets
+
+Drop the directive on the first line of the `.mmd`. Use a preset instead of inventing `classDef` tweaks ad hoc during review loops.
+
+## Light (brand-neutral)
+
+```text
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#eef2ff','primaryBorderColor':'#4f46e5','primaryTextColor':'#1e1b4b','lineColor':'#64748b','fontFamily':'Inter, sans-serif'}}}%%
+```
+
+## Dark
+
+```text
+%%{init: {'theme':'dark', 'themeVariables': {'fontFamily':'Inter, sans-serif'}}}%%
+```
+
+Export with `--backgroundColor dark` (or `#1e293b`) so the PNG blends into dark pages.
+
+## Print / documentation
+
+```text
+%%{init: {'theme':'neutral'}}%%
+```
+
+Also available as `mmdc --theme neutral` (no directive needed). Best contrast for printed PDFs.
+
+## Highlighting specific nodes (flowchart)
+
+```text
+classDef hot fill:#fee2e2,stroke:#dc2626,stroke-width:2px
+classDef done fill:#dcfce7,stroke:#16a34a
+class C,R hot
+class D,Del done
+```
+
+Use `hot` for the path under discussion, `done` for settled states. Two classDefs max — more turns into noise.
+
+## Gotchas
+
+- `base` is only valid **inside** a `%%{init}%%` directive — `mmdc -t base` is rejected (valid `-t` values: `default | dark | neutral | forest`).
+- The directive must be the first line; a blank line before it breaks parsing in some types.

--- a/plugins/mermaid/skills/mermaid-skill/reference/USECASE.md
+++ b/plugins/mermaid/skills/mermaid-skill/reference/USECASE.md
@@ -1,0 +1,87 @@
+# Use Case Diagram Syntax
+
+Use case diagrams (UML) show how actors interact with a system and its use cases. Available as `usecase-beta` (v11.17+).
+
+## Basic Structure
+
+```mermaid
+usecase-beta
+direction LR
+actor Customer("Customer")
+systemBoundary "Order system"
+  Checkout("Place order")
+end
+Customer --> Checkout
+```
+
+- `usecase-beta` — required first line
+- `direction` — `TD`, `TB`, `BT`, `LR`, or `RL`
+- Actors: `actor Name("Display label")` — stick figure by default
+- Use cases: `Name("label")` = ellipse, `Name[label]` = rectangle
+- `systemBoundary id["Title"] ... end` — groups actors/use cases (default `rect`, or `@{ type: package }`)
+
+## Actor Variants
+
+```mermaid
+usecase-beta
+actor Normal("Normal actor")
+actor Hollow("Hollow actor")@{ type: hollow }
+actor Awesome("Awesome actor")@{ type: awesome }
+actor Icon("Icon actor")@{ icon: "fa:user" }
+actor B2B("Sales agent")@{ business: true } <<Employee>>
+Normal --> Manage
+```
+
+- `type`: `hollow` | `awesome` (icon actors via `icon: "fa:name"`)
+- `business: true` adds the conventional business slash
+- `<<stereotype>>` adds a visible stereotype above the label
+
+## Relationships
+
+```mermaid
+usecase-beta
+actor Admin
+actor Person
+Checkout
+Payment
+ApplyCoupon
+Admin --|> Person                %% generalization
+Checkout ..> : include Payment   %% include
+ApplyCoupon ..> : extend Checkout %% extend
+User --> Start                   %% plain association
+User --o Start                   %% circle (aggregation-like)
+User --x Finish                  %% cross
+```
+
+| Operator | Meaning |
+| ---------- | --------- |
+| `-->`, `--`, `<--` | Association |
+| `--o`, `o--` | Circle-end association |
+| `--x`, `x--` | Cross-end association |
+| `..>` `: include X` | Include (source includes target) |
+| `..>` `: extend X` | Extend (source extends target) |
+| `--\|>` | Generalization (specialized → general) |
+
+## Notes and JSON Tables
+
+```mermaid
+usecase-beta
+note for Login "`Requires an **active session**`"
+actor User
+Login("Sign in")
+User --> Login
+
+json Payload@{
+  "status": "pending",
+  "items": [{ "name": "Book" }]
+}:::data
+Inspect --> Payload
+```
+
+- `note for <target> "text"` — attaches to an actor or use case
+- `json <id>@{ ... }` — renders a JSON object as a table node
+- Nested values use paths: `address.city`, `items[0].name`
+
+## Styling
+
+Classes and direct styles work like other Mermaid types: `classDef`, `class`, `style`, or `:::` suffix on declarations. Use `%%` for comments; `//` and `#` are NOT comments in usecase diagrams.

--- a/plugins/mermaid/skills/mermaid-skill/scripts/mermaid_live_link.py
+++ b/plugins/mermaid/skills/mermaid-skill/scripts/mermaid_live_link.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Encode a .mmd file into a mermaid.live editor URL (pako raw-deflate + base64url)."""
+
+import base64
+import json
+import sys
+import zlib
+
+
+def encode_link(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+    except OSError as e:
+        sys.exit(f"error: cannot read {path}: {e}")
+    state = json.dumps({"code": code, "mermaid": {"theme": "default"}}).encode()
+    compressor = zlib.compressobj(9, zlib.DEFLATED, -15)  # raw deflate, pako-compatible
+    data = compressor.compress(state) + compressor.flush()
+    b64 = base64.urlsafe_b64encode(data).decode().rstrip("=")
+    # round-trip guard: fail loudly rather than hand the user a broken link
+    pad = "=" * (-len(b64) % 4)
+    try:
+        decoded = zlib.decompress(base64.urlsafe_b64decode(b64 + pad), -15)
+        if json.loads(decoded)["code"] != code:
+            raise ValueError("round-trip decode mismatch")
+    except (ValueError, zlib.error) as e:
+        sys.exit(f"error: encoding self-check failed: {e}")
+    return f"https://mermaid.live/edit#pako:{b64}"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: mermaid_live_link.py diagram.mmd")
+    print(encode_link(sys.argv[1]))

--- a/plugins/mermaid/skills/mermaid-skill/scripts/puppeteer-config.json
+++ b/plugins/mermaid/skills/mermaid-skill/scripts/puppeteer-config.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+}


### PR DESCRIPTION
Mermaid plugin was stale (v1.0.0, old skill name creating-mermaid-diagrams). Synced to current mermaid-skill 1.3.0: renamed skill, expanded triggers, new reference/ docs (ARCHITECTURE, THEMES, USECASE, EXAMPLES), scripts/ (live link builder + puppeteer config), marketplace.json version bumped to 1.3.0. These 4 diagram skills (excalidraw/mermaid/plantuml/tldraw) will be maintained here going forward; their standalone repos are going private.