### PR TITLE
bump ttscn marketplace version to 1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,7 +106,7 @@
       "name": "ttscn",
       "source": "./plugins/ttscn",
       "description": "Multi-platform Chinese TTS text-to-speech — 8 China-friendly backends (Edge/Doubao/CosyVoice/Azure/Tencent/Baidu/MiniMax/Xunfei), agent-native CLI with JSON envelope, schema introspection, auto-detect TTY, distinct exit codes (0/1/2/3/4), structured errors (code/message/retryable/field/backend), --fields filtering, dry-run, JSON provider registry, filterable HTML comparison page, voice cloning, SSML, emotion, dialects.",
-      "version": "1.7.0",
+      "version": "1.9.0",
       "author": {
         "name": "Agents365-ai"
       },


### PR DESCRIPTION
Follow-up to #17: the ttsCN sync bumped SKILL.md to 1.9.0 but missed marketplace.json because the plugin entry name is lowercase 'ttscn' (the bump matched 'ttsCN'). Sets marketplace version to 1.9.0 to match the skill.