### PR TITLE
docs: make 365-skills agent-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # 365 Skills
 
-Production-grade Claude Code skills by [Agents365-ai](https://github.com/Agents365-ai).
+Production-grade skills for AI coding agents by [Agents365-ai](https://github.com/Agents365-ai). Agent-agnostic, works with Claude Code, Cursor, Copilot, OpenClaw & more.
 
 English | [中文](README_CN.md)
 
 ## Install
 
 ```bash
-# Claude Code plugin marketplace
-/plugin marketplace add Agents365-ai/365-skills
-
-# Any agent (Claude Code, Cursor, Copilot, etc.)
+# Any agent (Claude Code, Cursor, Copilot, etc.) — agent-agnostic
 npx skills add Agents365-ai/365-skills -g
+
+# Claude Code plugin marketplace (optional)
+/plugin marketplace add Agents365-ai/365-skills
 ```
 
 ## Available plugins
@@ -62,9 +62,11 @@ npx skills add Agents365-ai/365-skills -g
 | `bangumi-frames` | Bilibili anime frame & character organizer — download a bangumi/UP video (or local file), extract scene-change keyframes, split scenery vs character crops, cluster by CCIP identity or pull one character via a reference folder; optional OCR+LaMa subtitle/watermark removal |
 | `yt2bb` | Repurpose YouTube videos for Bilibili — download via yt-dlp, transcribe with whisper, generate bilingual (English-Chinese) SRT subtitles, hardcode them with ffmpeg |
 
-## Install plugins
+## Install individual plugins
 
-```
+Agent-agnostic install: `npx skills add Agents365-ai/365-skills` and pick the skill. Claude Code plugin path:
+
+```bash
 /plugin install drawio
 ```
 
@@ -79,33 +81,6 @@ git add plugins/drawio && git commit -m "chore: sync drawio-skill"
 ```
 
 Most source repos are now private; for those plugins this marketplace is the only distribution channel.
-
-## Source repos
-
-Each plugin mirrors a standalone skill repo — file issues there for plugin-specific bugs (private repos accept issues from collaborators only):
-
-| Plugin | Source |
-| --- | --- |
-| `agent-native-design` | [Agents365-ai/agent-native-design](https://github.com/Agents365-ai/agent-native-design) |
-| `drawio` | [Agents365-ai/drawio-skill](https://github.com/Agents365-ai/drawio-skill) |
-| `scholar-deep-research` | [Agents365-ai/scholar-deep-research](https://github.com/Agents365-ai/scholar-deep-research) |
-| `journal-abbrev` | [Agents365-ai/journal-abbrev](https://github.com/Agents365-ai/journal-abbrev) |
-| `video-podcast-maker` | [Agents365-ai/video-podcast-maker](https://github.com/Agents365-ai/video-podcast-maker) |
-| `obsidian-organizer` | [Agents365-ai/obsidian-organizer](https://github.com/Agents365-ai/obsidian-organizer) |
-| `asta` | Agents365-ai/asta-skill (private) |
-| `bangumi-frames` | Agents365-ai/bangumi-frames (private) |
-| `excalidraw` | Agents365-ai/excalidraw-skill (private) |
-| `imagencn` | Agents365-ai/imagencn (private) |
-| `mermaid` | Agents365-ai/mermaid-skill (private) |
-| `paper-fetch` | Agents365-ai/paper-fetch (private) |
-| `pi-plugin-cc` | Agents365-ai/pi-plugin-cc (private) |
-| `plantuml` | Agents365-ai/plantuml-skill (private) |
-| `semanticscholar` | Agents365-ai/semanticscholar-skill (private) |
-| `target-prioritization` | Agents365-ai/target-prioritization (private) |
-| `tldraw` | Agents365-ai/tldraw-skill (private) |
-| `ttscn` | Agents365-ai/ttscn (private) |
-| `videogencn` | distributed via this repo only |
-| `yt2bb` | Agents365-ai/yt2bb (private) |
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,3 @@ If this skill set is helpful, consider supporting the author:
 
 - Bilibili: <https://space.bilibili.com/441831884>
 - GitHub: <https://github.com/Agents365-ai>
-
-## Other resources
-
-- [K-Dense-AI/scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) — community collection of scientific-research skills
-- [anthropics/life-sciences](https://github.com/anthropics/life-sciences) — Anthropic's life-sciences skills

--- a/README_CN.md
+++ b/README_CN.md
@@ -125,8 +125,3 @@ git add plugins/drawio && git commit -m "chore: sync drawio-skill"
 
 - Bilibili: <https://space.bilibili.com/441831884>
 - GitHub: <https://github.com/Agents365-ai>
-
-## 其他资源
-
-- [K-Dense-AI/scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) —— 社区维护的科研类 skill 合集
-- [anthropics/life-sciences](https://github.com/anthropics/life-sciences) —— Anthropic 官方的生命科学 skills

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,17 +1,17 @@
 # 365 Skills
 
-[Agents365-ai](https://github.com/Agents365-ai) 出品的生产级 Claude Code 技能集合。
+[Agents365-ai](https://github.com/Agents365-ai) 出品，面向各类 AI 编码智能体的生产级技能集合。与 Agent 无关，兼容 Claude Code、Cursor、Copilot、OpenClaw 等。
 
 [English](README.md) | 中文
 
 ## 安装
 
 ```bash
-# Claude Code 插件市场
-/plugin marketplace add Agents365-ai/365-skills
-
-# 任意 Agent 工具（Claude Code、Cursor、Copilot 等）
+# 任意 Agent 工具（Claude Code、Cursor、Copilot 等）—— Agent 无关
 npx skills add Agents365-ai/365-skills -g
+
+# Claude Code 插件市场（可选）
+/plugin marketplace add Agents365-ai/365-skills
 ```
 
 ## 可用插件
@@ -62,9 +62,11 @@ npx skills add Agents365-ai/365-skills -g
 | `bangumi-frames` | B 站番剧帧与角色整理 —— 下载番剧/UP 主视频（或本地文件），抽取场景切换关键帧，拆分风景与角色裁剪，按 CCIP 身份聚类或通过参考文件夹提取单个角色；可选 OCR+LaMa 去字幕/水印 |
 | `yt2bb` | YouTube 视频搬运至 B 站 —— yt-dlp 下载、whisper 转写、生成中英双语 SRT 字幕并用 ffmpeg 硬编码 |
 
-## 安装插件
+## 单独安装插件
 
-```
+与 Agent 无关的安装方式：`npx skills add Agents365-ai/365-skills` 后选择对应技能。Claude Code 插件路径：
+
+```bash
 /plugin install drawio
 ```
 
@@ -79,33 +81,6 @@ git add plugins/drawio && git commit -m "chore: sync drawio-skill"
 ```
 
 多数源仓库现已转为私有；对这部分插件而言，本 marketplace 是唯一分发渠道。
-
-## 源仓库
-
-每个插件都对应一个独立的 skill 仓库 —— 与具体插件相关的 bug 请到对应仓库提交 issue（私有仓库仅协作者可提 issue）：
-
-| 插件 | 源仓库 |
-| --- | --- |
-| `agent-native-design` | [Agents365-ai/agent-native-design](https://github.com/Agents365-ai/agent-native-design) |
-| `drawio` | [Agents365-ai/drawio-skill](https://github.com/Agents365-ai/drawio-skill) |
-| `scholar-deep-research` | [Agents365-ai/scholar-deep-research](https://github.com/Agents365-ai/scholar-deep-research) |
-| `journal-abbrev` | [Agents365-ai/journal-abbrev](https://github.com/Agents365-ai/journal-abbrev) |
-| `video-podcast-maker` | [Agents365-ai/video-podcast-maker](https://github.com/Agents365-ai/video-podcast-maker) |
-| `obsidian-organizer` | [Agents365-ai/obsidian-organizer](https://github.com/Agents365-ai/obsidian-organizer) |
-| `asta` | Agents365-ai/asta-skill（私有） |
-| `bangumi-frames` | Agents365-ai/bangumi-frames（私有） |
-| `excalidraw` | Agents365-ai/excalidraw-skill（私有） |
-| `imagencn` | Agents365-ai/imagencn（私有） |
-| `mermaid` | Agents365-ai/mermaid-skill（私有） |
-| `paper-fetch` | Agents365-ai/paper-fetch（私有） |
-| `pi-plugin-cc` | Agents365-ai/pi-plugin-cc（私有） |
-| `plantuml` | Agents365-ai/plantuml-skill（私有） |
-| `semanticscholar` | Agents365-ai/semanticscholar-skill（私有） |
-| `target-prioritization` | Agents365-ai/target-prioritization（私有） |
-| `tldraw` | Agents365-ai/tldraw-skill（私有） |
-| `ttscn` | Agents365-ai/ttscn（私有） |
-| `videogencn` | 仅通过本仓库分发 |
-| `yt2bb` | Agents365-ai/yt2bb（私有） |
 
 ## 微信交流群
 


### PR DESCRIPTION
## What & why

Reposition **365-skills** as a cross-agent skills collection rather than a Claude Code marketplace:

- Subtitle + install order now lead with the agent-agnostic `npx skills add` path; the Claude Code plugin marketplace becomes an optional channel.
- Drop the `Source repos` section (the plugin↔source-repo mapping) from both READMEs.

GitHub repo About/topics were updated separately via `gh repo edit` (added `ai-agents`/`coding-agents`, dropped `claude-code-skill`/`claude-skills`; rewrote description to be agent-agnostic).

> Only the two README files are in this PR. Unrelated working-tree changes (ttscn `azure.py`, video-podcast-maker React components) were intentionally left out.