### PR TITLE
docs: optimize readme + register journal-if

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Agents365-ai"
   },
   "metadata": {
-    "description": "Production-grade Claude Code skills — diagramming, visualization, and more"
+    "description": "Production-grade skills for AI coding agents — diagrams, scientific research, CLI & agent design, notes, and AI media generation"
   },
   "plugins": [
     {
@@ -241,6 +241,25 @@
         "bibtex",
         "jabref",
         "citation",
+        "academic",
+        "research"
+      ]
+    },
+    {
+      "name": "journal-if",
+      "source": "./plugins/journal-if",
+      "description": "Journal impact factor (JCR IF) lookup — find a journal's IF by name, compare IF across journals, and rank publication venue quality, backed by a bundled journals_if.csv dataset and a local Python CLI",
+      "version": "1.0.0",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/journal-if",
+      "license": "MIT",
+      "keywords": [
+        "journal-impact-factor",
+        "jcr",
+        "impact-factor",
+        "journal-rank",
         "academic",
         "research"
       ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -111,7 +111,7 @@
         "name": "Agents365-ai"
       },
       "repository": "https://github.com/Agents365-ai/ttscn",
-      "license": "CC-BY-NC-4.0",
+      "license": "MIT",
       "keywords": [
         "tts",
         "text-to-speech",
@@ -273,7 +273,7 @@
         "name": "Agents365-ai"
       },
       "repository": "https://github.com/Agents365-ai/target-prioritization",
-      "license": "PolyForm-NC-1.0.0",
+      "license": "MIT",
       "keywords": [
         "drug-discovery",
         "target-prioritization",
@@ -294,7 +294,7 @@
         "name": "Agents365-ai"
       },
       "repository": "https://github.com/Agents365-ai/pi-plugin-cc",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "keywords": [
         "pi",
         "coding-agent",
@@ -315,7 +315,7 @@
         "name": "Agents365-ai"
       },
       "repository": "https://github.com/Agents365-ai/videogencn",
-      "license": "CC-BY-NC-4.0",
+      "license": "MIT",
       "keywords": [
         "video-generation",
         "text-to-video",
@@ -340,7 +340,7 @@
         "name": "Agents365-ai"
       },
       "repository": "https://github.com/Agents365-ai/assetseeker",
-      "license": "CC-BY-NC-4.0",
+      "license": "MIT",
       "keywords": [
         "assets",
         "stock-photos",
@@ -459,7 +459,7 @@
         "name": "Agents365-ai"
       },
       "repository": "https://github.com/Agents365-ai/obsidian-organizer",
-      "license": "CC-BY-NC-4.0",
+      "license": "MIT",
       "keywords": [
         "obsidian",
         "notes",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # 365 Skills
 
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/network/members)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
 Production-grade skills for AI coding agents by [Agents365-ai](https://github.com/Agents365-ai). Agent-agnostic, works with Claude Code, Cursor, Copilot, OpenClaw & more.
 
 English | [中文](README_CN.md)
@@ -7,12 +15,14 @@ English | [中文](README_CN.md)
 ## Install
 
 ```bash
-# Any agent (Claude Code, Cursor, Copilot, etc.) — agent-agnostic
+# Agent-agnostic — any agent (Claude Code, Cursor, Copilot, etc.)
 npx skills add Agents365-ai/365-skills -g
 
 # Claude Code plugin marketplace (optional)
 /plugin marketplace add Agents365-ai/365-skills
 ```
+
+Install a single plugin (Claude Code): `/plugin install <plugin-name>`, e.g. `/plugin install drawio`.
 
 ## Available plugins
 
@@ -42,6 +52,7 @@ npx skills add Agents365-ai/365-skills -g
 | `scholar-deep-research` | End-to-end literature review pipeline — 8-phase script-driven workflow, 7 federated sources (OpenAlex, arXiv, Crossref, PubMed, DBLP, bioRxiv, Exa), cross-source dedup, dual-backend citation chasing, parallel deep-read fan-out, mandatory self-critique, cited reports across 5 archetypes |
 | `asta` | Ai2 Asta MCP — Semantic Scholar academic graph over MCP (no Python). Intent-to-tool routing, safe `fields` defaults, citation traversal, snippet evidence retrieval, and DOI/arXiv/PMID via `externalIds` |
 | `journal-abbrev` | Journal name abbreviation lookup — ISO 4 + MEDLINE, multi-source cascade (JabRef → AbbrevISO → NLM), BibTeX rewrite with `--idempotency-key`, atomic cache rebuild, agent-native JSON envelope with stable error codes and dry-run |
+| `journal-if` | Journal impact factor (JCR IF) lookup — find a journal's IF by name, compare IF across journals, and rank publication venue quality, backed by a bundled `journals_if.csv` dataset |
 | `target-prioritization` | Multi-source drug-target due-diligence — turn a ranked gene list (e.g. scRNA-seq DE output) into a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan, then re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic |
 
 ### Knowledge & notes
@@ -61,14 +72,6 @@ npx skills add Agents365-ai/365-skills -g
 | `video-podcast-maker` | Automated topic-driven video podcast creation — research → script → TTS (7 backends) → 4K Remotion render → BGM mix → Remotion-native subtitles. Multi-platform output (Bilibili / YouTube / Xiaohongshu / Douyin / WeChat Channels), horizontal long-form (16:9 4K) and vertical shorts (9:16), 15-step workflow with mandatory Studio preview |
 | `bangumi-frames` | Bilibili anime frame & character organizer — download a bangumi/UP video (or local file), extract scene-change keyframes, split scenery vs character crops, cluster by CCIP identity or pull one character via a reference folder; optional OCR+LaMa subtitle/watermark removal |
 | `yt2bb` | Repurpose YouTube videos for Bilibili — download via yt-dlp, transcribe with whisper, generate bilingual (English-Chinese) SRT subtitles, hardcode them with ffmpeg |
-
-## Install individual plugins
-
-Agent-agnostic install: `npx skills add Agents365-ai/365-skills` and pick the skill. Claude Code plugin path:
-
-```bash
-/plugin install drawio
-```
 
 ## Development
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,5 +1,13 @@
 # 365 Skills
 
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/network/members)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
 [Agents365-ai](https://github.com/Agents365-ai) 出品，面向各类 AI 编码智能体的生产级技能集合。与 Agent 无关，兼容 Claude Code、Cursor、Copilot、OpenClaw 等。
 
 [English](README.md) | 中文
@@ -7,12 +15,14 @@
 ## 安装
 
 ```bash
-# 任意 Agent 工具（Claude Code、Cursor、Copilot 等）—— Agent 无关
+# 任意 Agent 工具（Claude Code、Cursor、Copilot 等）—— 与 Agent 无关
 npx skills add Agents365-ai/365-skills -g
 
 # Claude Code 插件市场（可选）
 /plugin marketplace add Agents365-ai/365-skills
 ```
+
+单插件的 Claude Code 安装：`/plugin install <插件名>`，例如 `/plugin install drawio`。
 
 ## 可用插件
 
@@ -42,6 +52,7 @@ npx skills add Agents365-ai/365-skills -g
 | `scholar-deep-research` | 端到端文献综述流水线 —— 8 阶段脚本驱动工作流，跨 7 个数据源（OpenAlex、arXiv、Crossref、PubMed、DBLP、bioRxiv、Exa）联邦检索、去重、双 backend 引用追溯、并行精读派发、强制自我批判，输出 5 种原型的带引用报告 |
 | `asta` | Ai2 Asta MCP —— Semantic Scholar 学术图谱以 MCP 暴露（无需 Python）。意图到工具的路由、安全 `fields` 默认值（避免上下文炸开）、引文遍历、片段证据检索，并通过 `externalIds` 获取 DOI / arXiv / PMID |
 | `journal-abbrev` | 期刊名称缩写查询 —— 支持 ISO 4 与 MEDLINE 两种标准，多源级联（JabRef → AbbrevISO → NLM）、BibTeX 字段批量重写并支持 `--idempotency-key` 幂等重试、原子缓存重建，agent-native JSON 信封带稳定错误码与 dry-run |
+| `journal-if` | 期刊影响因子（JCR IF）查询 —— 按名称查期刊 IF、跨期刊比较、评估投稿期刊档次，内置 `journals_if.csv` 数据集 |
 | `target-prioritization` | 多源药物靶点尽职调查 —— 将排序基因列表（如 scRNA-seq 差异表达输出）转化为逐基因档案（UniProt、OpenTargets、PubMed），叠加本地跨谱系差异表达扫描，再按可配置综合评分（跨谱系趋同 + 成药性 + 疾病遗传学 + 可开发性 + 新颖性）重排。疾病无关，可配置靶疾病与细胞上下文查询 |
 
 ### 知识与笔记
@@ -61,14 +72,6 @@ npx skills add Agents365-ai/365-skills -g
 | `video-podcast-maker` | 自动化主题驱动视频播客制作 —— 选题研究 → 脚本 → TTS（7 后端）→ 4K Remotion 渲染 → BGM 混音 → Remotion 原生字幕。多平台输出（B 站 / YouTube / 小红书 / 抖音 / 视频号），横版长视频（16:9 4K）与竖版 shorts（9:16），15 步工作流强制 Studio 预览 |
 | `bangumi-frames` | B 站番剧帧与角色整理 —— 下载番剧/UP 主视频（或本地文件），抽取场景切换关键帧，拆分风景与角色裁剪，按 CCIP 身份聚类或通过参考文件夹提取单个角色；可选 OCR+LaMa 去字幕/水印 |
 | `yt2bb` | YouTube 视频搬运至 B 站 —— yt-dlp 下载、whisper 转写、生成中英双语 SRT 字幕并用 ffmpeg 硬编码 |
-
-## 单独安装插件
-
-与 Agent 无关的安装方式：`npx skills add Agents365-ai/365-skills` 后选择对应技能。Claude Code 插件路径：
-
-```bash
-/plugin install drawio
-```
 
 ## 开发
 


### PR DESCRIPTION
## What

Four README/marketplace optimizations (per review):

1. **Merge duplicate install sections** — the top `## Install` and mid-file `## Install individual plugins` overlapped; now one section, single-plugin Claude Code install folded in.
2. **Badge row** under the H1 (stars / forks / last-commit / SkillsMP / Claude Code plugin / Agent Skills). Omitted a License badge — the repo has no LICENSE so a license badge would be misleading.
3. **Register `journal-if`** — it existed at `plugins/journal-if/` but was in **neither** the README catalog **nor** `marketplace.json`, so it was undeliverable. Added the marketplace entry + README row (Scientific research). License set to MIT (the org/repo convention; source repo is private so couldn't verify independently).
4. **Refresh marketplace `metadata.description`** — was stale ('Production-grade Claude Code skills — diagramming, visualization, and more'); updated to agent-agnostic to match the repo description.

Plus the `ttsCN`→`ttscn` casing: verified no change needed — git already tracks the dir as lowercase `plugins/ttscn` (the `ttsCN` display was a case-insensitive macOS artifact). On Linux clones it checks out lowercase as intended.

> Only READMEs + `marketplace.json` here. Unrelated working-tree changes (ttscn `azure.py`, video-podcast-maker components) intentionally left out.