### PR TITLE
style: apply biome/ruff autofix across synced plugins

### DIFF
--- a/plugins/ttscn/skills/ttscn/scripts/backends/azure.py
+++ b/plugins/ttscn/skills/ttscn/scripts/backends/azure.py
@@ -60,7 +60,7 @@ def synthesize(chunks, config, output_file, output_format="wav"):
     )
     voice = config.get("voice", "zh-CN-XiaoxiaoNeural")
     # azure SDK stubs not installed in this env; runtime attribute is valid
-    setattr(speech_config, "SpeechSynthesisVoiceName", voice)  # pyright: ignore[reportAttributeAccessIssue]
+    speech_config.SpeechSynthesisVoiceName = voice  # pyright: ignore[reportAttributeAccessIssue]
     speech_rate = config.get("speech_rate", "+5%")
 
     out_dir = os.path.dirname(output_file) or "."

--- a/plugins/video-podcast-maker/skills/video-podcast-maker/templates/components/AnimatedBackground.tsx
+++ b/plugins/video-podcast-maker/skills/video-podcast-maker/templates/components/AnimatedBackground.tsx
@@ -14,283 +14,273 @@
 
 import { useCurrentFrame, useVideoConfig, interpolate, spring } from "remotion";
 import {
-      useFloat,
-      usePulse,
-      useGradientShift,
-      useOpacityWave,
+  useFloat,
+  usePulse,
+  useGradientShift,
+  useOpacityWave,
 } from "./animations";
 
 // --- Moving Gradient Background ---
 // Slowly rotating gradient that adds subtle motion to any section
 export const MovingGradient = ({
-      color1 = "#4f6ef7",
-      color2 = "#FF6B6B",
-      opacity = 0.08,
-      speed = 0.3,
+  color1 = "#4f6ef7",
+  color2 = "#FF6B6B",
+  opacity = 0.08,
+  speed = 0.3,
 }: {
-      color1?: string;
-      color2?: string;
-      opacity?: number;
-      speed?: number;
+  color1?: string;
+  color2?: string;
+  opacity?: number;
+  speed?: number;
 }) => {
-      const { angle } = useGradientShift(speed);
+  const { angle } = useGradientShift(speed);
 
-      return (
-            <div
-                  style={{
-                        position: "absolute",
-                        inset: 0,
-                        background: `linear-gradient(${angle}deg, ${color1}${Math.round(
-                              opacity * 255,
-                        )
-                              .toString(16)
-                              .padStart(
-                                    2,
-                                    "0",
-                              )}, transparent 50%, ${color2}${Math.round(
-                              opacity * 255,
-                        )
-                              .toString(16)
-                              .padStart(2, "0")})`,
-                        pointerEvents: "none",
-                  }}
-            />
-      );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        background: `linear-gradient(${angle}deg, ${color1}${Math.round(
+          opacity * 255,
+        )
+          .toString(16)
+          .padStart(2, "0")}, transparent 50%, ${color2}${Math.round(
+          opacity * 255,
+        )
+          .toString(16)
+          .padStart(2, "0")})`,
+        pointerEvents: "none",
+      }}
+    />
+  );
 };
 
 // --- Floating Shapes ---
 // Gentle drifting geometric shapes for depth and visual interest
 const SHAPE_CONFIGS = [
-      { size: 180, x: 85, y: 15, period: 140, phase: 0 },
-      { size: 120, x: 10, y: 75, period: 160, phase: 40 },
-      { size: 90, x: 70, y: 80, period: 130, phase: 80 },
-      { size: 200, x: 5, y: 20, period: 170, phase: 20 },
-      { size: 60, x: 50, y: 10, period: 110, phase: 60 },
-      { size: 140, x: 90, y: 55, period: 150, phase: 100 },
-      { size: 70, x: 30, y: 90, period: 120, phase: 30 },
+  { size: 180, x: 85, y: 15, period: 140, phase: 0 },
+  { size: 120, x: 10, y: 75, period: 160, phase: 40 },
+  { size: 90, x: 70, y: 80, period: 130, phase: 80 },
+  { size: 200, x: 5, y: 20, period: 170, phase: 20 },
+  { size: 60, x: 50, y: 10, period: 110, phase: 60 },
+  { size: 140, x: 90, y: 55, period: 150, phase: 100 },
+  { size: 70, x: 30, y: 90, period: 120, phase: 30 },
 ];
 
 export const FloatingShapes = ({
-      color = "#4f6ef7",
-      count = 5,
-      opacity = 0.06,
-      shape = "circle",
+  color = "#4f6ef7",
+  count = 5,
+  opacity = 0.06,
+  shape = "circle",
 }: {
-      color?: string;
-      count?: number;
-      opacity?: number;
-      shape?: "circle" | "hexagon" | "ring";
+  color?: string;
+  count?: number;
+  opacity?: number;
+  shape?: "circle" | "hexagon" | "ring";
 }) => {
-      const configs = SHAPE_CONFIGS.slice(
-            0,
-            Math.min(count, SHAPE_CONFIGS.length),
-      );
+  const configs = SHAPE_CONFIGS.slice(0, Math.min(count, SHAPE_CONFIGS.length));
 
-      return (
-            <div
-                  style={{
-                        position: "absolute",
-                        inset: 0,
-                        overflow: "hidden",
-                        pointerEvents: "none",
-                  }}
-            >
-                  {configs.map((cfg, i) => (
-                        <FloatingShape
-                              key={i}
-                              config={cfg}
-                              color={color}
-                              opacity={opacity}
-                              shape={shape}
-                        />
-                  ))}
-            </div>
-      );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+      }}
+    >
+      {configs.map((cfg, i) => (
+        <FloatingShape
+          key={i}
+          config={cfg}
+          color={color}
+          opacity={opacity}
+          shape={shape}
+        />
+      ))}
+    </div>
+  );
 };
 
 const FloatingShape = ({
-      config,
-      color,
-      opacity,
-      shape,
+  config,
+  color,
+  opacity,
+  shape,
 }: {
-      config: (typeof SHAPE_CONFIGS)[0];
-      color: string;
-      opacity: number;
-      shape: "circle" | "hexagon" | "ring";
+  config: (typeof SHAPE_CONFIGS)[0];
+  color: string;
+  opacity: number;
+  shape: "circle" | "hexagon" | "ring";
 }) => {
-      const { translateY, translateX } = useFloat(
-            15,
-            config.period,
-            config.phase,
-      );
-      const { scale } = usePulse(0.9, 1.1, config.period * 1.3, config.phase);
+  const { translateY, translateX } = useFloat(15, config.period, config.phase);
+  const { scale } = usePulse(0.9, 1.1, config.period * 1.3, config.phase);
 
-      const borderRadius =
-            shape === "circle" ? "50%" : shape === "hexagon" ? "25%" : "50%";
-      const bg = shape === "ring" ? "transparent" : color;
-      const border = shape === "ring" ? `3px solid ${color}` : "none";
+  const borderRadius =
+    shape === "circle" ? "50%" : shape === "hexagon" ? "25%" : "50%";
+  const bg = shape === "ring" ? "transparent" : color;
+  const border = shape === "ring" ? `3px solid ${color}` : "none";
 
-      return (
-            <div
-                  style={{
-                        position: "absolute",
-                        left: `${config.x}%`,
-                        top: `${config.y}%`,
-                        width: config.size,
-                        height: config.size,
-                        borderRadius,
-                        backgroundColor: bg,
-                        border,
-                        opacity,
-                        transform: `translate(${translateX}px, ${translateY}px) scale(${scale})`,
-                        filter: "blur(1px)",
-                  }}
-            />
-      );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: `${config.x}%`,
+        top: `${config.y}%`,
+        width: config.size,
+        height: config.size,
+        borderRadius,
+        backgroundColor: bg,
+        border,
+        opacity,
+        transform: `translate(${translateX}px, ${translateY}px) scale(${scale})`,
+        filter: "blur(1px)",
+      }}
+    />
+  );
 };
 
 // --- Grid / Dot Pattern ---
 // Subtle repeating pattern overlay for texture
 export const GridPattern = ({
-      color = "#4f6ef7",
-      opacity = 0.04,
-      spacing = 60,
-      dotSize = 2,
-      variant = "dots",
+  color = "#4f6ef7",
+  opacity = 0.04,
+  spacing = 60,
+  dotSize = 2,
+  variant = "dots",
 }: {
-      color?: string;
-      opacity?: number;
-      spacing?: number;
-      dotSize?: number;
-      variant?: "dots" | "lines" | "crosses";
+  color?: string;
+  opacity?: number;
+  spacing?: number;
+  dotSize?: number;
+  variant?: "dots" | "lines" | "crosses";
 }) => {
-      let backgroundImage: string;
+  let backgroundImage: string;
 
-      if (variant === "dots") {
-            backgroundImage = `radial-gradient(circle, ${color} ${dotSize}px, transparent ${dotSize}px)`;
-      } else if (variant === "lines") {
-            backgroundImage = `
+  if (variant === "dots") {
+    backgroundImage = `radial-gradient(circle, ${color} ${dotSize}px, transparent ${dotSize}px)`;
+  } else if (variant === "lines") {
+    backgroundImage = `
       linear-gradient(${color}${Math.round(opacity * 255)
-            .toString(16)
-            .padStart(2, "0")} 1px, transparent 1px),
+        .toString(16)
+        .padStart(2, "0")} 1px, transparent 1px),
       linear-gradient(90deg, ${color}${Math.round(opacity * 255)
-            .toString(16)
-            .padStart(2, "0")} 1px, transparent 1px)
+        .toString(16)
+        .padStart(2, "0")} 1px, transparent 1px)
     `;
-      } else {
-            // crosses
-            backgroundImage = `
+  } else {
+    // crosses
+    backgroundImage = `
       radial-gradient(circle, ${color} ${dotSize}px, transparent ${dotSize}px),
       linear-gradient(${color}${Math.round(opacity * 255 * 0.5)
-            .toString(16)
-            .padStart(2, "0")} 1px, transparent 1px),
+        .toString(16)
+        .padStart(2, "0")} 1px, transparent 1px),
       linear-gradient(90deg, ${color}${Math.round(opacity * 255 * 0.5)
-            .toString(16)
-            .padStart(2, "0")} 1px, transparent 1px)
+        .toString(16)
+        .padStart(2, "0")} 1px, transparent 1px)
     `;
-      }
+  }
 
-      return (
-            <div
-                  style={{
-                        position: "absolute",
-                        inset: 0,
-                        backgroundImage,
-                        backgroundSize:
-                              variant === "dots"
-                                    ? `${spacing}px ${spacing}px`
-                                    : `${spacing}px ${spacing}px`,
-                        opacity: variant === "dots" ? opacity : 1,
-                        pointerEvents: "none",
-                  }}
-            />
-      );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        backgroundImage,
+        backgroundSize:
+          variant === "dots"
+            ? `${spacing}px ${spacing}px`
+            : `${spacing}px ${spacing}px`,
+        opacity: variant === "dots" ? opacity : 1,
+        pointerEvents: "none",
+      }}
+    />
+  );
 };
 
 // --- Glow Orb ---
 // Large pulsing color orb for focal point emphasis
 export const GlowOrb = ({
-      color = "#4f6ef7",
-      size = 400,
-      x = "50%",
-      y = "40%",
-      opacity = 0.12,
-      blur = 80,
+  color = "#4f6ef7",
+  size = 400,
+  x = "50%",
+  y = "40%",
+  opacity = 0.12,
+  blur = 80,
 }: {
-      color?: string;
-      size?: number;
-      x?: string;
-      y?: string;
-      opacity?: number;
-      blur?: number;
+  color?: string;
+  size?: number;
+  x?: string;
+  y?: string;
+  opacity?: number;
+  blur?: number;
 }) => {
-      const { scale } = usePulse(0.85, 1.15, 150);
-      const pulseOpacity = useOpacityWave(180, opacity * 0.7, opacity);
+  const { scale } = usePulse(0.85, 1.15, 150);
+  const pulseOpacity = useOpacityWave(180, opacity * 0.7, opacity);
 
-      return (
-            <div
-                  style={{
-                        position: "absolute",
-                        left: x,
-                        top: y,
-                        width: size,
-                        height: size,
-                        borderRadius: "50%",
-                        background: `radial-gradient(circle, ${color}, transparent 70%)`,
-                        opacity: pulseOpacity,
-                        transform: `translate(-50%, -50%) scale(${scale})`,
-                        filter: `blur(${blur}px)`,
-                        pointerEvents: "none",
-                  }}
-            />
-      );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: x,
+        top: y,
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: `radial-gradient(circle, ${color}, transparent 70%)`,
+        opacity: pulseOpacity,
+        transform: `translate(-50%, -50%) scale(${scale})`,
+        filter: `blur(${blur}px)`,
+        pointerEvents: "none",
+      }}
+    />
+  );
 };
 
 // --- Decorative Accent Line ---
 // Animated line that grows from center, good for section dividers
 export const AccentLine = ({
-      color = "#4f6ef7",
-      width = 120,
-      thickness = 3,
-      delay = 10,
-      position = "top",
+  color = "#4f6ef7",
+  width = 120,
+  thickness = 3,
+  delay = 10,
+  position = "top",
 }: {
-      color?: string;
-      width?: number;
-      thickness?: number;
-      delay?: number;
-      position?: "top" | "bottom" | "center";
+  color?: string;
+  width?: number;
+  thickness?: number;
+  delay?: number;
+  position?: "top" | "bottom" | "center";
 }) => {
-      const frame = useCurrentFrame();
-      const { fps } = useVideoConfig();
-      const progress = spring({
-            frame,
-            fps,
-            delay,
-            config: { damping: 200 },
-            durationInFrames: 30,
-      });
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const progress = spring({
+    frame,
+    fps,
+    delay,
+    config: { damping: 200 },
+    durationInFrames: 30,
+  });
 
-      const scaleX = interpolate(progress, [0, 1], [0, 1]);
-      const top =
-            position === "top" ? 0 : position === "center" ? "50%" : undefined;
-      const bottom = position === "bottom" ? 0 : undefined;
+  const scaleX = interpolate(progress, [0, 1], [0, 1]);
+  const top =
+    position === "top" ? 0 : position === "center" ? "50%" : undefined;
+  const bottom = position === "bottom" ? 0 : undefined;
 
-      return (
-            <div
-                  style={{
-                        position: "absolute",
-                        left: "50%",
-                        top,
-                        bottom,
-                        width,
-                        height: thickness,
-                        borderRadius: thickness,
-                        background: `linear-gradient(90deg, transparent, ${color}, transparent)`,
-                        transform: `translateX(-50%) scaleX(${scaleX})`,
-                        pointerEvents: "none",
-                  }}
-            />
-      );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: "50%",
+        top,
+        bottom,
+        width,
+        height: thickness,
+        borderRadius: thickness,
+        background: `linear-gradient(90deg, transparent, ${color}, transparent)`,
+        transform: `translateX(-50%) scaleX(${scaleX})`,
+        pointerEvents: "none",
+      }}
+    />
+  );
 };

--- a/plugins/video-podcast-maker/skills/video-podcast-maker/templates/components/AssetImage.tsx
+++ b/plugins/video-podcast-maker/skills/video-podcast-maker/templates/components/AssetImage.tsx
@@ -15,69 +15,69 @@ import { useAssets, getAsset, assetSrc } from "./useAssets";
  * or unresolved, so compositions stay safe on text-only videos.
  */
 export const AssetImage = ({
-  props,
-  id,
-  src,
-  role = "inline",
-  caption,
-  layout = "full",
-  kenBurns = true,
-  dim = 0.35,
-  delay = 0,
+    props,
+    id,
+    src,
+    role = "inline",
+    caption,
+    layout = "full",
+    kenBurns = true,
+    dim = 0.35,
+    delay = 0,
 }: {
-  props: VideoProps;
-  id?: string;
-  src?: string;
-  role?: "background" | "inline";
-  caption?: string;
-  layout?: "full" | "card";
-  kenBurns?: boolean;
-  dim?: number;
-  delay?: number;
+    props: VideoProps;
+    id?: string;
+    src?: string;
+    role?: "background" | "inline";
+    caption?: string;
+    layout?: "full" | "card";
+    kenBurns?: boolean;
+    dim?: number;
+    delay?: number;
 }) => {
-  const manifest = useAssets();
-  const frame = useCurrentFrame();
+    const manifest = useAssets();
+    const frame = useCurrentFrame();
 
-  const entry = id ? getAsset(manifest, id) : null;
-  const resolvedSrc = src ?? (entry ? assetSrc(entry) : null);
-  if (!resolvedSrc) return null;
+    const entry = id ? getAsset(manifest, id) : null;
+    const resolvedSrc = src ?? (entry ? assetSrc(entry) : null);
+    if (!resolvedSrc) return null;
 
-  if (role === "background") {
-    // Slow push-in over ~20s, clamped — subtle motion for static backgrounds
-    const scale =
-      kenBurns && props.enableAnimations
-        ? interpolate(frame, [0, 600], [1.04, 1.14], {
-            extrapolateRight: "clamp",
-          })
-        : 1;
+    if (role === "background") {
+        // Slow push-in over ~20s, clamped — subtle motion for static backgrounds
+        const scale =
+            kenBurns && props.enableAnimations
+                ? interpolate(frame, [0, 600], [1.04, 1.14], {
+                      extrapolateRight: "clamp",
+                  })
+                : 1;
+        return (
+            <AbsoluteFill>
+                <Img
+                    src={resolvedSrc}
+                    style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                        transform: `scale(${scale})`,
+                    }}
+                />
+                {/* Scrim keeps foreground text readable on any photo */}
+                <AbsoluteFill
+                    style={{
+                        background: `linear-gradient(180deg, rgba(0,0,0,${dim * 0.7}) 0%, rgba(0,0,0,${dim}) 100%)`,
+                    }}
+                />
+            </AbsoluteFill>
+        );
+    }
+
     return (
-      <AbsoluteFill>
-        <Img
-          src={resolvedSrc}
-          style={{
-            width: "100%",
-            height: "100%",
-            objectFit: "cover",
-            transform: `scale(${scale})`,
-          }}
+        <MediaSection
+            props={props}
+            src={resolvedSrc}
+            caption={caption ?? entry?.credit}
+            layout={layout}
+            delay={delay}
         />
-        {/* Scrim keeps foreground text readable on any photo */}
-        <AbsoluteFill
-          style={{
-            background: `linear-gradient(180deg, rgba(0,0,0,${dim * 0.7}) 0%, rgba(0,0,0,${dim}) 100%)`,
-          }}
-        />
-      </AbsoluteFill>
     );
-  }
-
-  return (
-    <MediaSection
-      props={props}
-      src={resolvedSrc}
-      caption={caption ?? entry?.credit}
-      layout={layout}
-      delay={delay}
-    />
-  );
 };

--- a/plugins/video-podcast-maker/skills/video-podcast-maker/templates/components/AssetVideo.tsx
+++ b/plugins/video-podcast-maker/skills/video-podcast-maker/templates/components/AssetVideo.tsx
@@ -14,68 +14,68 @@ import { useAssets, getAsset, assetSrc } from "./useAssets";
  * Renders nothing when the asset is absent or unresolved.
  */
 export const AssetVideo = ({
-      props,
-      id,
-      src,
-      role = "inline",
-      dim = 0.35,
-      muted = true,
-      delay = 0,
+  props,
+  id,
+  src,
+  role = "inline",
+  dim = 0.35,
+  muted = true,
+  delay = 0,
 }: {
-      props: VideoProps;
-      id?: string;
-      src?: string;
-      role?: "background" | "inline";
-      dim?: number;
-      muted?: boolean;
-      delay?: number;
+  props: VideoProps;
+  id?: string;
+  src?: string;
+  role?: "background" | "inline";
+  dim?: number;
+  muted?: boolean;
+  delay?: number;
 }) => {
-      const manifest = useAssets();
-      const a = useEntrance(props.enableAnimations, delay, "gentle");
+  const manifest = useAssets();
+  const a = useEntrance(props.enableAnimations, delay, "gentle");
 
-      const entry = id ? getAsset(manifest, id) : null;
-      const resolvedSrc = src ?? (entry ? assetSrc(entry) : null);
-      if (!resolvedSrc) return null;
+  const entry = id ? getAsset(manifest, id) : null;
+  const resolvedSrc = src ?? (entry ? assetSrc(entry) : null);
+  if (!resolvedSrc) return null;
 
-      if (role === "background") {
-            return (
-                  <AbsoluteFill>
-                        <OffthreadVideo
-                              src={resolvedSrc}
-                              muted={muted}
-                              style={{
-                                    width: "100%",
-                                    height: "100%",
-                                    objectFit: "cover",
-                              }}
-                        />
-                        <AbsoluteFill
-                              style={{
-                                    background: `linear-gradient(180deg, rgba(0,0,0,${dim * 0.7}) 0%, rgba(0,0,0,${dim}) 100%)`,
-                              }}
-                        />
-                  </AbsoluteFill>
-            );
-      }
+  if (role === "background") {
+    return (
+      <AbsoluteFill>
+        <OffthreadVideo
+          src={resolvedSrc}
+          muted={muted}
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+          }}
+        />
+        <AbsoluteFill
+          style={{
+            background: `linear-gradient(180deg, rgba(0,0,0,${dim * 0.7}) 0%, rgba(0,0,0,${dim}) 100%)`,
+          }}
+        />
+      </AbsoluteFill>
+    );
+  }
 
-      const c = props.primaryColor;
-      return (
-            <div
-                  style={{
-                        width: "100%",
-                        borderRadius: 24,
-                        overflow: "hidden",
-                        border: `3px solid ${c}30`,
-                        boxShadow: `0 8px 32px ${c}15, 0 16px 48px rgba(0,0,0,0.08)`,
-                        opacity: a.opacity,
-                        transform: `translateY(${a.translateY}px) scale(${a.scale})`,
-                  }}
-            >
-                  <OffthreadVideo
-                        src={resolvedSrc}
-                        muted={muted}
-                        style={{ width: "100%", display: "block" }}
-                  />
-            </div>
-      );
+  const c = props.primaryColor;
+  return (
+    <div
+      style={{
+        width: "100%",
+        borderRadius: 24,
+        overflow: "hidden",
+        border: `3px solid ${c}30`,
+        boxShadow: `0 8px 32px ${c}15, 0 16px 48px rgba(0,0,0,0.08)`,
+        opacity: a.opacity,
+        transform: `translateY(${a.translateY}px) scale(${a.scale})`,
+      }}
+    >
+      <OffthreadVideo
+        src={resolvedSrc}
+        muted={muted}
+        style={{ width: "100%", display: "block" }}
+      />
+    </div>
+  );
 };


### PR DESCRIPTION
## What

A biome/ruff autofix pass on files left uncommitted in the working tree:

- Re-indent the three video-podcast-maker Remotion components (`AnimatedBackground`, `AssetImage`, `AssetVideo`).
- Switch `ttscn` `azure.py` from `setattr(...)` to direct attribute assignment.

## Why

Matches the repo's established convention (`91311f9d style: apply ruff/biome autofix formatting across synced plugins`, `28c467f5 ... azure setattr`). No logic change — formatting/lint only.

Note: PR #13 (Atlas Cloud TTS) is unrelated and was left open per your call.