### PR TITLE
Add README and LICENSE files to moved plugins

### DIFF
--- a/plugins/asta/LICENSE
+++ b/plugins/asta/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/asta/README.md
+++ b/plugins/asta/README.md
@@ -1,0 +1,479 @@
+# asta-skill — Semantic Scholar via Ai2 Asta MCP
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/asta-skill?style=flat&logo=github)](https://github.com/Agents365-ai/asta-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/asta-skill?style=flat&logo=github)](https://github.com/Agents365-ai/asta-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/asta-skill?logo=github)](https://github.com/Agents365-ai/asta-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/asta-skill?logo=github)](https://github.com/Agents365-ai/asta-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-asta-skill-skills-asta-skill-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/asta-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+**English** · [中文](README_CN.md) · [Asta MCP Overview](https://allenai.org/asta/resources/mcp) · [Request API Key](https://share.hsforms.com/1L4hUh20oT3mu8iXJQMV77w3ioxm)
+
+Ai2's Asta MCP server (Semantic Scholar) runs on **any MCP-capable agent** — this repo adds an *optional* pure instruction-pack skill on top that turns natural-language research questions into well-formed tool calls: it routes intent → tool, fills safe defaults, chains workflows, and warns you off the usual pitfalls. Register the MCP server and you can call Asta from **Claude Code, Cursor, Codex, Windsurf, Trae, Qoder, CodeBuddy/WorkBuddy, Hermes, opencode, OpenClaw, pi-mono**, and anything else that speaks MCP; add the skill (on any [Agent Skills](https://agentskills.io)-compatible host) for sharper results.
+
+## What it does
+
+- **Search** the Semantic Scholar academic corpus by keyword, title, author, or full-text snippet
+- **Look up** a paper from any ID (DOI, arXiv, PMID, PMCID, CorpusId, MAG, ACL, SHA, URL)
+- **Traverse citations** — find who cited a given paper, with filtering and pagination
+- **Batch-lookup** multiple papers in one call via `get_paper_batch`
+- **Snippet search** — retrieve ~500-word passages from paper bodies for evidence grounding
+- **Author discovery** — find researchers and list their publications
+- **Zero-code integration** — the skill is a pure instruction pack; all I/O goes through the Asta MCP server
+- Triggers automatically whenever the user asks for papers, citations, academic search, or literature discovery and Asta tools are registered
+
+## Multi-Platform Support
+
+**Anything that speaks MCP can call Asta** — the skill is just an optional [Agent Skills](https://agentskills.io) layer on top. Verified on **Claude Code, Codex, Cursor, Devin Desktop (ex-Windsurf), Hermes, opencode, OpenClaw/ClawHub,** and **[pi-mono](https://github.com/badlogic/pi-mono)**; indexed on **SkillsMP**. The [Installation](#installation) section below has copy-paste setup for those plus **Gemini CLI, GitHub Copilot, Cline, Trae, 通义灵码 Lingma, CodeBuddy/WorkBuddy, Qoder, Claude Desktop,** and **LM Studio**. Desktop hosts that don't auto-load skills (Claude Desktop, LM Studio) still get the tools over MCP — paste `SKILL.md` into the system prompt to add the routing layer.
+
+`SKILL.md`'s frontmatter keeps only `name`, `description`, and `license` at the top level (all other fields are nested under `metadata`), so it validates cleanly under stricter skill-frontmatter parsers such as Codex's.
+
+## Prerequisites
+
+- An agent host with MCP support (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, Cline, Devin Desktop, Trae, 通义灵码 Lingma, CodeBuddy/WorkBuddy, Qoder, opencode, OpenClaw/ClawHub, pi-mono, etc.)
+- An Asta API key — [request here](https://share.hsforms.com/1L4hUh20oT3mu8iXJQMV77w3ioxm)
+
+  ```bash
+  export ASTA_API_KEY=xxxxxxxxxxxxxxxx
+  ```
+
+## Installation
+
+**Registering the MCP server is all you strictly need** — Asta runs on **any MCP-capable agent**, and the tools work the moment the server connects. [Step 2](#step-2-install-the-skill-optional) adds an *optional* instruction layer (intent→tool routing, safe defaults, pitfall guards); the tools work fine without it.
+
+### Step 1: Register the Asta MCP Server
+
+Every host points at the same endpoint — **`https://asta-tools.allen.ai/mcp/v1`**, streamable HTTP, authenticated with an **`x-api-key`** header. The only catch is that hosts name the fields differently (`url` vs `serverUrl` vs `httpUrl`, `mcpServers` vs `servers`), and a few can't attach a custom header at all — those bridge through [`mcp-remote`](https://www.npmjs.com/package/mcp-remote). Expand your agent:
+
+**Terminal / CLI**
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+```bash
+claude mcp add -t http -s user asta https://asta-tools.allen.ai/mcp/v1 \
+  -H "x-api-key: $ASTA_API_KEY"
+```
+
+Restart Claude Code so the MCP tools load at session start.
+
+</details>
+
+<details>
+<summary><b>Codex CLI</b></summary>
+
+Edit `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.asta]
+url = "https://asta-tools.allen.ai/mcp/v1"
+env_http_headers = { "x-api-key" = "ASTA_API_KEY" }
+```
+
+Codex infers streamable HTTP from `url`. `env_http_headers` maps the header to the **env-var name** to read from — export `ASTA_API_KEY`. For a literal key, use `http_headers = { "x-api-key" = "<YOUR_API_KEY>" }`.
+
+</details>
+
+<details>
+<summary><b>Gemini CLI</b></summary>
+
+Edit `~/.gemini/settings.json` — note Gemini CLI uses **`httpUrl`** for streamable HTTP:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "httpUrl": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>GitHub Copilot CLI</b></summary>
+
+One command (or `/mcp add` interactively):
+
+```bash
+copilot mcp add --transport http --header "x-api-key: <YOUR_API_KEY>" \
+  asta https://asta-tools.allen.ai/mcp/v1
+```
+
+Or edit `~/.copilot/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "type": "http",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" },
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+(The older `gh copilot` extension — `suggest`/`explain` — is a command helper, not an MCP host.)
+
+</details>
+
+**Editors & IDEs**
+
+<details>
+<summary><b>Cursor</b></summary>
+
+Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${env:ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+Cursor expands `${env:ASTA_API_KEY}` from your shell (or hardcode the key). Reload, then confirm the server turns green in **Settings → MCP**.
+
+</details>
+
+<details>
+<summary><b>GitHub Copilot (VS Code / Visual Studio)</b></summary>
+
+Create `.vscode/mcp.json` — VS Code's root key is **`servers`**, not `mcpServers`:
+
+```json
+{
+  "servers": {
+    "asta": {
+      "type": "http",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${env:ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+Turn on **Agent mode** in Copilot Chat, then start the server from the `mcp.json` gutter action.
+
+</details>
+
+<details>
+<summary><b>Cline</b></summary>
+
+MCP Servers → **Remote Servers**, or edit `cline_mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "type": "streamableHttp",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+Set `"type": "streamableHttp"` explicitly — omitting it falls back to legacy SSE.
+
+</details>
+
+<details>
+<summary><b>Devin Desktop (formerly Windsurf)</b></summary>
+
+Windsurf was rebranded **Devin Desktop** on 2026-06-02; existing MCP settings carry over. Edit `mcp_config.json` (migrated Windsurf path: `~/.codeium/windsurf/mcp_config.json`) — note the key is **`serverUrl`**, not `url`:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "serverUrl": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${env:ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+Then press **Refresh** in the MCP panel. (The separately-shipped *Windsurf Plugin* for VS Code / JetBrains kept its old name — use the generic block below for it.)
+
+</details>
+
+**IDE (China)**
+
+<details>
+<summary><b>Trae (ByteDance)</b></summary>
+
+AI sidebar → **MCP** → **Add** → **Add Manually**, then paste:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>通义灵码 Lingma (Alibaba)</b></summary>
+
+MCP panel → **Add MCP** → form config: set transport to **SSE / streamable HTTP**, URL `https://asta-tools.allen.ai/mcp/v1`, and add a header `x-api-key` = `<YOUR_API_KEY>`. Lingma also accepts the script (JSON) form with the standard `mcpServers` + `url` + `headers` shape.
+
+</details>
+
+<details>
+<summary><b>CodeBuddy / WorkBuddy (Tencent)</b></summary>
+
+Edit `~/.codebuddy/.mcp.json` (user scope) or `<project>/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "type": "http",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+`${ASTA_API_KEY}` expands from the environment. WorkBuddy is OpenClaw-compatible, so the optional skill also loads from its OpenClaw skills directory.
+
+</details>
+
+<details>
+<summary><b>Qoder (Alibaba)</b></summary>
+
+Qoder's remote-server JSON doesn't expose a custom-header field, so bridge through [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (requires [Node.js](https://nodejs.org)). Settings (`⌘⇧,`) → **MCP** → **+ Add**:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://asta-tools.allen.ai/mcp/v1", "--header", "x-api-key:${ASTA_API_KEY}"],
+      "env": { "ASTA_API_KEY": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+Write `x-api-key:${ASTA_API_KEY}` with **no space** after the colon.
+
+</details>
+
+**Desktop & local** — MCP tools work once connected, but these hosts don't auto-load skills, so paste `SKILL.md` in manually for the routing layer.
+
+<details>
+<summary><b>Claude Desktop</b></summary>
+
+Claude Desktop's built-in **Add custom connector** UI only supports OAuth — it can't attach the `x-api-key` header Asta needs, so a server added there fails to register. Register through the config file using the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge instead (requires [Node.js](https://nodejs.org)).
+
+Edit `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/`, Windows: `%APPDATA%\Claude\`):
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://asta-tools.allen.ai/mcp/v1",
+        "--header",
+        "x-api-key:${ASTA_API_KEY}"
+      ],
+      "env": { "ASTA_API_KEY": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+Write the header as `x-api-key:${ASTA_API_KEY}` with **no space** after the colon — Claude Desktop splits `--header` args on spaces — and supply the value via `env`. Then fully quit and reopen Claude Desktop. To add the skill's intent routing / safe defaults, paste the body of [`skills/asta-skill/SKILL.md`](skills/asta-skill/SKILL.md) into a Project's instructions.
+
+</details>
+
+<details>
+<summary><b>LM Studio</b></summary>
+
+LM Studio (0.3.17+) speaks MCP but does not auto-discover Agent Skills. Two steps:
+
+1. **Register the MCP server** — App Settings → Program → Integrations → edit `mcp.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "asta": {
+          "url": "https://asta-tools.allen.ai/mcp/v1",
+          "headers": { "x-api-key": "YOUR_ASTA_API_KEY" }
+        }
+      }
+    }
+    ```
+
+2. **Paste the skill instructions** — copy the body of [`skills/asta-skill/SKILL.md`](skills/asta-skill/SKILL.md) into the chat's System Prompt so the model follows the intent routing and safe defaults.
+
+Use a **tool-calling-capable** local model (e.g. Qwen2.5-Instruct, Llama 3.1 Instruct, Mistral Nemo, GPT-OSS). Plain chat models cannot invoke MCP tools.
+
+</details>
+
+<details>
+<summary><b>Any other MCP host</b></summary>
+
+Point it at the standard streamable-HTTP config:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+If your client can't attach a custom header to a remote server, bridge through [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (see the **Qoder** or **Claude Desktop** blocks).
+
+</details>
+
+### Step 2: Install the Skill (optional)
+
+Skip this and the tools still work — this layer only sharpens tool selection and defaults. The skill body lives at `skills/asta-skill/SKILL.md`. The easiest path is the plugin marketplace.
+
+#### Plugin marketplace (recommended)
+
+```bash
+# Any agent (Claude Code, Cursor, Copilot, etc.)
+npx skills add Agents365-ai/365-skills -g
+
+# Claude Code only
+/plugin marketplace add Agents365-ai/365-skills
+/plugin install asta
+```
+
+Also indexed on [SkillsMP](https://skillsmp.com/) and [ClawHub](https://clawhub.ai/) — each handles updates through its own marketplace.
+
+#### Manual clone (any host)
+
+```bash
+git clone https://github.com/Agents365-ai/asta-skill.git /tmp/asta-skill
+cp -r /tmp/asta-skill/skills/asta-skill <your-host's-skills-dir>/asta-skill
+```
+
+### Verification
+
+After registering the MCP server, installing the skill, and restarting your host, ask:
+
+> "Use Asta to get the paper ARXIV:1706.03762 with fields title,year,authors,venue,tldr"
+
+A successful call returns *Attention Is All You Need*, NeurIPS 2017, Vaswani et al., with TLDR.
+
+## Usage
+
+Just describe what you want:
+
+```
+> Use Asta to get the paper with DOI 10.48550/arXiv.1706.03762
+
+> Search Asta for recent papers on mixture-of-experts at NeurIPS since 2023
+
+> Who cited "Attention Is All You Need"? Show me the top 20 by citation count
+
+> Find snippets in the Asta corpus that mention "flash attention latency"
+
+> Look up Yann LeCun on Asta and list his 2024 papers
+```
+
+The skill picks the right Asta tool, attaches safe `fields`, and follows the documented workflow patterns.
+
+### Example: Search + Batch Download (chained with `paper-fetch`)
+
+`asta-skill` only handles **search and metadata**; it does not download PDFs. To go from a search query to local PDFs, chain it with a `paper-fetch` skill (or any DOI-based downloader of your choice):
+
+```
+> Use Asta to find the 5 most cited papers on "single-cell ATAC-seq batch correction"
+  since 2022, then hand the DOIs to paper-fetch to download all PDFs into ./papers/
+```
+
+What happens under the hood:
+
+1. **asta-skill** → `search_papers_by_relevance` with `publication_date_range="2022:"` and `fields=title,year,authors,venue,tldr,externalIds` (note `externalIds` to expose DOI)
+2. Agent extracts `externalIds.DOI` for each hit; falls back to `externalIds.ArXiv` when DOI is absent
+3. **paper-fetch** → batch-resolves each DOI/arXiv ID through the Unpaywall → Semantic Scholar → arXiv → PubMed Central → bioRxiv/medRxiv → publisher-direct → Sci-Hub fallback chain
+4. PDFs land in `./papers/`, one per paper
+
+`paper-fetch` is a separate skill — install it if you need download capability. `asta-skill` itself stays scoped to the Semantic Scholar corpus.
+
+**Step 1 — Asta returns the top 5 papers with DOIs:**
+
+![Asta search result](assets/asta-search.png)
+
+**Step 2 — paper-fetch downloads all 5 PDFs into `./papers/`:**
+
+![paper-fetch batch download](assets/asta-paper-fetch.png)
+
+## 🔗 Related Skills
+
+Part of the [Agents365-ai research-skill family](https://github.com/Agents365-ai) — pick the right tool for the job:
+
+| Skill | Niche | When to use |
+| --- | --- | --- |
+| [semanticscholar-skill](https://github.com/Agents365-ai/semanticscholar-skill) | Direct Semantic Scholar API (Python) | When MCP isn't available or you prefer scripted access |
+| [paper-fetch](https://github.com/Agents365-ai/paper-fetch) | DOI → PDF, 7-source fallback | When you need full text after finding citations |
+| [scholar-deep-research](https://github.com/Agents365-ai/scholar-deep-research) | 8-phase literature review pipeline | When the user wants a structured cited report |
+
+## ❤️ Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="Give a Reward">
+      <br>
+      <b>Give a Reward</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 Author
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/plugins/asta/README_CN.md
+++ b/plugins/asta/README_CN.md
@@ -1,0 +1,479 @@
+# asta-skill — 通过 Ai2 Asta MCP 访问 Semantic Scholar
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/asta-skill?style=flat&logo=github)](https://github.com/Agents365-ai/asta-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/asta-skill?style=flat&logo=github)](https://github.com/Agents365-ai/asta-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/asta-skill?logo=github)](https://github.com/Agents365-ai/asta-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/asta-skill?logo=github)](https://github.com/Agents365-ai/asta-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-asta-skill-skills-asta-skill-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/asta-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+[English](README.md) · **中文** · [Asta MCP 介绍](https://allenai.org/asta/resources/mcp) · [申请 API Key](https://share.hsforms.com/1L4hUh20oT3mu8iXJQMV77w3ioxm)
+
+Ai2 的 Asta MCP server(Semantic Scholar)可在**任意支持 MCP 的 agent** 上运行 —— 本仓库在其之上额外提供一个*可选*的纯指令包技能,把自然语言研究问题转换为规范的工具调用:负责意图路由 → 工具选择、安全默认值填充、工作流编排,并提示常见陷阱。只要注册好 MCP server,就能在 **Claude Code、Cursor、Codex、Windsurf、Trae、Qoder、CodeBuddy/WorkBuddy、Hermes、opencode、OpenClaw、pi-mono** 以及任何支持 MCP 的 agent 上调用 Asta;在任意兼容 [Agent Skills](https://agentskills.io) 的 host 上再加载本技能可获得更精准的结果。
+
+## 功能特性
+
+- **搜索** Semantic Scholar 学术语料库,支持关键词、标题、作者、全文片段多种检索方式
+- **查论文** —— 支持 DOI、arXiv、PMID、PMCID、CorpusId、MAG、ACL、SHA、URL 等任意 ID 格式
+- **引用遍历** —— 查找某篇论文被谁引用,支持过滤与分页
+- **批量查找** —— 通过 `get_paper_batch` 一次查询多篇论文
+- **片段检索** —— 从论文正文中提取 ~500 词的相关段落,用于证据溯源
+- **作者检索** —— 查找研究者并列出其发表论文
+- **零代码集成** —— 本技能是纯指令包,所有 I/O 通过 Asta MCP server 完成
+- 当用户提出论文、引用、学术搜索、文献发现相关需求且 Asta 工具已注册时自动触发
+
+## 多平台支持
+
+**任何支持 MCP 的工具都能调用 Asta** —— 本技能只是其上一个可选的 [Agent Skills](https://agentskills.io) 层。已在 **Claude Code、Codex、Cursor、Devin Desktop(原 Windsurf)、Hermes、opencode、OpenClaw/ClawHub、[pi-mono](https://github.com/badlogic/pi-mono)** 上验证,并收录于 **SkillsMP**。下方[安装](#安装)一节还提供了 **Gemini CLI、GitHub Copilot、Cline、Trae、通义灵码 Lingma、CodeBuddy/WorkBuddy、Qoder、Claude Desktop、LM Studio** 的可复制配置。不自动加载 skills 的桌面端(Claude Desktop、LM Studio)连上 MCP 后工具即可用 —— 把 `SKILL.md` 粘到 system prompt 即可补上路由层。
+
+`SKILL.md` 的 frontmatter 仅在顶层保留 `name`、`description`、`license`,其余字段全部嵌套在 `metadata` 下,因此能通过 Codex 等更严格的 skill frontmatter 解析器的校验。
+
+## 前置条件
+
+- 任意支持 MCP 的 agent host(Claude Code、Cursor、Codex、Gemini CLI、GitHub Copilot、Cline、Devin Desktop、Trae、通义灵码 Lingma、CodeBuddy/WorkBuddy、Qoder、opencode、OpenClaw/ClawHub、pi-mono 等)
+- Asta API key —— [点此申请](https://share.hsforms.com/1L4hUh20oT3mu8iXJQMV77w3ioxm)
+
+  ```bash
+  export ASTA_API_KEY=xxxxxxxxxxxxxxxx
+  ```
+
+## 安装
+
+**注册 MCP server 就够了** —— Asta 可在**任意支持 MCP 的 agent** 上运行,server 一连上工具即可用。[第 2 步](#第-2-步安装技能可选)只是加了一个*可选*的指令层(意图路由 → 工具选择、安全默认值、陷阱提示),没有它工具照样能用。
+
+### 第 1 步：注册 Asta MCP 服务器
+
+所有 host 都指向同一个端点 —— **`https://asta-tools.allen.ai/mcp/v1`**,streamable HTTP,用 **`x-api-key`** 请求头鉴权。唯一的坑是各家字段名不一样(`url` / `serverUrl` / `httpUrl`,`mcpServers` / `servers`),还有少数无法附加自定义请求头 —— 这些改用 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) 桥接。展开你用的 agent:
+
+**终端 / CLI**
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+```bash
+claude mcp add -t http -s user asta https://asta-tools.allen.ai/mcp/v1 \
+  -H "x-api-key: $ASTA_API_KEY"
+```
+
+重启 Claude Code,MCP 工具会在会话启动时加载。
+
+</details>
+
+<details>
+<summary><b>Codex CLI</b></summary>
+
+编辑 `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.asta]
+url = "https://asta-tools.allen.ai/mcp/v1"
+env_http_headers = { "x-api-key" = "ASTA_API_KEY" }
+```
+
+Codex 通过 `url` 自动识别 streamable HTTP。`env_http_headers` 把请求头映射到**读取其值的环境变量名** —— 需 export `ASTA_API_KEY`。若想写死 key,改用 `http_headers = { "x-api-key" = "<YOUR_API_KEY>" }`。
+
+</details>
+
+<details>
+<summary><b>Gemini CLI</b></summary>
+
+编辑 `~/.gemini/settings.json` —— 注意 Gemini CLI 用 **`httpUrl`** 表示 streamable HTTP:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "httpUrl": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>GitHub Copilot CLI</b></summary>
+
+一行命令（或交互式 `/mcp add`）：
+
+```bash
+copilot mcp add --transport http --header "x-api-key: <YOUR_API_KEY>" \
+  asta https://asta-tools.allen.ai/mcp/v1
+```
+
+或编辑 `~/.copilot/mcp-config.json`：
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "type": "http",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" },
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+（旧的 `gh copilot` 扩展 —— `suggest`/`explain` —— 只是命令建议助手,不托管 MCP。）
+
+</details>
+
+**编辑器 / IDE**
+
+<details>
+<summary><b>Cursor</b></summary>
+
+编辑 `~/.cursor/mcp.json`(全局)或 `.cursor/mcp.json`(项目级):
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${env:ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+Cursor 会从 shell 展开 `${env:ASTA_API_KEY}`(或直接写死 key)。重载后在 **Settings → MCP** 里确认该 server 变绿。
+
+</details>
+
+<details>
+<summary><b>GitHub Copilot(VS Code / Visual Studio)</b></summary>
+
+新建 `.vscode/mcp.json` —— VS Code 的根键是 **`servers`**,不是 `mcpServers`:
+
+```json
+{
+  "servers": {
+    "asta": {
+      "type": "http",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${env:ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+在 Copilot Chat 里打开 **Agent 模式**,再从 `mcp.json` 的行号旁操作启动该 server。
+
+</details>
+
+<details>
+<summary><b>Cline</b></summary>
+
+MCP Servers → **Remote Servers**,或编辑 `cline_mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "type": "streamableHttp",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+务必显式写 `"type": "streamableHttp"` —— 不写会回退到旧的 SSE 传输。
+
+</details>
+
+<details>
+<summary><b>Devin Desktop(原 Windsurf)</b></summary>
+
+Windsurf 已于 2026-06-02 更名为 **Devin Desktop**,原有 MCP 配置自动迁移。编辑 `mcp_config.json`(迁移前的 Windsurf 路径:`~/.codeium/windsurf/mcp_config.json`)—— 注意键名是 **`serverUrl`**,不是 `url`:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "serverUrl": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${env:ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+然后在 MCP 面板点 **Refresh**。(单独发布的 *Windsurf Plugin*(VS Code / JetBrains 插件)保留原名,用下方通用块即可。)
+
+</details>
+
+**国内 IDE**
+
+<details>
+<summary><b>Trae(字节跳动)</b></summary>
+
+AI 侧边栏 → **MCP** → **Add** → **Add Manually**,粘贴:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>通义灵码 Lingma(阿里云)</b></summary>
+
+MCP 面板 → **添加 MCP** → 表单配置:传输方式选 **SSE / streamable HTTP**,URL 填 `https://asta-tools.allen.ai/mcp/v1`,再加一个请求头 `x-api-key` = `<YOUR_API_KEY>`。灵码也支持脚本(JSON)配置,格式为标准的 `mcpServers` + `url` + `headers`。
+
+</details>
+
+<details>
+<summary><b>CodeBuddy / WorkBuddy(腾讯)</b></summary>
+
+编辑 `~/.codebuddy/.mcp.json`(用户级)或 `<项目根>/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "type": "http",
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "${ASTA_API_KEY}" }
+    }
+  }
+}
+```
+
+`${ASTA_API_KEY}` 会从环境变量展开。WorkBuddy 兼容 OpenClaw,所以可选技能也能从其 OpenClaw 技能目录加载。
+
+</details>
+
+<details>
+<summary><b>Qoder(阿里)</b></summary>
+
+Qoder 的远程 server JSON 不支持自定义请求头,需用 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) 桥接(需 [Node.js](https://nodejs.org))。设置(`⌘⇧,`)→ **MCP** → **+ Add**:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://asta-tools.allen.ai/mcp/v1", "--header", "x-api-key:${ASTA_API_KEY}"],
+      "env": { "ASTA_API_KEY": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+`x-api-key:${ASTA_API_KEY}` 冒号后**不要加空格**。
+
+</details>
+
+**桌面端 / 本地** —— 连上 MCP 后工具即可用,但这些 host 不自动加载技能,需手动把 `SKILL.md` 粘进去以获得路由层。
+
+<details>
+<summary><b>Claude Desktop</b></summary>
+
+Claude Desktop 自带的 **Add custom connector**(添加自定义连接器)界面只支持 OAuth —— 无法附加 Asta 所需的 `x-api-key` 请求头,在那里添加的服务器会注册失败。请改用 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) 桥接、通过配置文件注册(需安装 [Node.js](https://nodejs.org))。
+
+编辑 `claude_desktop_config.json`(macOS:`~/Library/Application Support/Claude/`,Windows:`%APPDATA%\Claude\`):
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://asta-tools.allen.ai/mcp/v1",
+        "--header",
+        "x-api-key:${ASTA_API_KEY}"
+      ],
+      "env": { "ASTA_API_KEY": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+请求头要写成 `x-api-key:${ASTA_API_KEY}`,冒号后**不要加空格** —— Claude Desktop 会按空格拆分 `--header` 参数 —— 并通过 `env` 传入实际 key。然后彻底退出并重开 Claude Desktop。若想要技能的意图路由 / 安全默认值,把 [`skills/asta-skill/SKILL.md`](skills/asta-skill/SKILL.md) 的正文粘贴到某个 Project 的指令中即可。
+
+</details>
+
+<details>
+<summary><b>LM Studio</b></summary>
+
+LM Studio(0.3.17+)已支持 MCP,但不会自动加载 Agent Skills。两步即可使用:
+
+1. **注册 MCP server** —— App Settings → Program → Integrations → 编辑 `mcp.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "asta": {
+          "url": "https://asta-tools.allen.ai/mcp/v1",
+          "headers": { "x-api-key": "YOUR_ASTA_API_KEY" }
+        }
+      }
+    }
+    ```
+
+2. **手动注入技能指令** —— 把 [`skills/asta-skill/SKILL.md`](skills/asta-skill/SKILL.md) 的正文复制到聊天的 System Prompt,让模型按意图路由表和安全默认值调用工具。
+
+需使用**支持 function calling 的本地模型**(如 Qwen2.5-Instruct、Llama 3.1 Instruct、Mistral Nemo、GPT-OSS),纯 chat 模型无法调用 MCP 工具。
+
+</details>
+
+<details>
+<summary><b>其他任意 MCP host</b></summary>
+
+指向标准的 streamable HTTP 配置:
+
+```json
+{
+  "mcpServers": {
+    "asta": {
+      "url": "https://asta-tools.allen.ai/mcp/v1",
+      "headers": { "x-api-key": "<YOUR_API_KEY>" }
+    }
+  }
+}
+```
+
+若你的客户端无法给远程 server 附加自定义请求头,用 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) 桥接(参考上面的 **Qoder** 或 **Claude Desktop** 块)。
+
+</details>
+
+### 第 2 步：安装技能（可选）
+
+跳过这步工具照样能用 —— 这一层只是让工具选择和默认值更精准。技能正文位于仓库内的 `skills/asta-skill/SKILL.md`。最简单的安装方式是通过插件市场。
+
+#### 插件市场(推荐)
+
+```bash
+# 任意 agent(Claude Code、Cursor、Copilot 等)
+npx skills add Agents365-ai/365-skills -g
+
+# 仅 Claude Code
+/plugin marketplace add Agents365-ai/365-skills
+/plugin install asta
+```
+
+同时收录于 [SkillsMP](https://skillsmp.com/) 与 [ClawHub](https://clawhub.ai/) —— 各自通过自己的市场处理更新。
+
+#### 手动克隆(任意 host)
+
+```bash
+git clone https://github.com/Agents365-ai/asta-skill.git /tmp/asta-skill
+cp -r /tmp/asta-skill/skills/asta-skill <你的-host-的-skills-目录>/asta-skill
+```
+
+### 验证
+
+注册好 MCP server、安装好技能并重启 host 后,向 agent 提问:
+
+> "用 Asta 查论文 ARXIV:1706.03762,字段要 title,year,authors,venue,tldr"
+
+成功调用应返回 *Attention Is All You Need*,NeurIPS 2017,Vaswani 等人,含 TLDR。
+
+## 使用方式
+
+直接用自然语言描述需求即可:
+
+```
+> 用 Asta 查一下 DOI 10.48550/arXiv.1706.03762 这篇论文
+
+> 在 Asta 上搜索 2023 年以来 NeurIPS 的 mixture-of-experts 论文
+
+> "Attention Is All You Need" 被哪些论文引用?按引用数排前 20
+
+> 在 Asta 语料库中查找提到 "flash attention latency" 的段落
+
+> 在 Asta 上找 Yann LeCun,列出他 2024 年的论文
+```
+
+技能会选对 Asta 工具、附上安全的 `fields` 参数,并遵循文档中的工作流模板。
+
+### 示例：检索 + 批量下载（与 `paper-fetch` 联用）
+
+`asta-skill` 只负责**检索和元数据获取**,不下载 PDF。如果要从搜索结果直接拿到本地 PDF,可与 `paper-fetch` 技能(或任意基于 DOI 的下载工具)串联使用:
+
+```
+> 用 Asta 检索 2022 年以来 "single-cell ATAC-seq batch correction" 引用最高的 5 篇论文,
+  然后把 DOI 交给 paper-fetch 批量下载到 ./papers/ 目录
+```
+
+底层流程:
+
+1. **asta-skill** → 调用 `search_papers_by_relevance`,参数 `publication_date_range="2022:"`,`fields=title,year,authors,venue,tldr,externalIds`(注意带上 `externalIds` 才能拿到 DOI)
+2. Agent 从结果中提取 `externalIds.DOI`；没有 DOI 时回退到 `externalIds.ArXiv`
+3. **paper-fetch** → 批量按 Unpaywall → Semantic Scholar → arXiv → PubMed Central → bioRxiv/medRxiv → publisher-direct → Sci-Hub 顺序解析每个 DOI/arXiv ID
+4. PDF 落到 `./papers/`,每篇一个文件
+
+`paper-fetch` 是独立技能,需要下载能力时单独安装。`asta-skill` 本身职责仅限 Semantic Scholar 语料。
+
+**Step 1 — Asta 返回 Top 5 论文(含 DOI)：**
+
+![Asta 检索结果](assets/asta-search.png)
+
+**Step 2 — paper-fetch 把 5 篇 PDF 全部下载到 `./papers/`：**
+
+![paper-fetch 批量下载](assets/asta-paper-fetch.png)
+
+## 🔗 相关技能
+
+属于 [Agents365-ai 科研技能家族](https://github.com/Agents365-ai) —— 按场景挑选合适工具:
+
+| 技能 | 定位 | 何时使用 |
+| --- | --- | --- |
+| [semanticscholar-skill](https://github.com/Agents365-ai/semanticscholar-skill) | 直连 Semantic Scholar API(Python) | 无法使用 MCP,或更想脚本化访问时 |
+| [paper-fetch](https://github.com/Agents365-ai/paper-fetch) | DOI → PDF,7 源回退 | 找到引用后需要全文时 |
+| [scholar-deep-research](https://github.com/Agents365-ai/scholar-deep-research) | 8 阶段文献综述流水线 | 用户需要结构化、带引用的综述报告时 |
+
+## ❤️ 支持
+
+如果这个技能对你有帮助,欢迎打赏支持作者:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="打赏">
+      <br>
+      <b>打赏</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 作者
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/plugins/excalidraw/LICENSE
+++ b/plugins/excalidraw/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/excalidraw/README.md
+++ b/plugins/excalidraw/README.md
@@ -1,0 +1,317 @@
+# excalidraw-skill — Clean & Hand-Drawn Diagrams from Natural Language
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/excalidraw-skill?style=flat&logo=github&cacheSeconds=86400)](https://github.com/Agents365-ai/excalidraw-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/excalidraw-skill?style=flat&logo=github&cacheSeconds=86400)](https://github.com/Agents365-ai/excalidraw-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/excalidraw-skill?logo=github&cacheSeconds=86400)](https://github.com/Agents365-ai/excalidraw-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/excalidraw-skill?logo=github&cacheSeconds=3600)](https://github.com/Agents365-ai/excalidraw-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-excalidraw-skill-skills-excalidraw-skill-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/excalidraw-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+**English** · [中文](README_CN.md) · [📖 Online Docs](https://agents365-ai.github.io/excalidraw-skill/)
+
+A skill that turns natural-language descriptions into clean, professional `.excalidraw` JSON files — or hand-drawn sketches when you want them — and exports them to PNG / SVG, either via the zero-install [Kroki](https://kroki.io) API or the local [`excalidraw-brute-export-cli`](https://www.npmjs.com/package/excalidraw-brute-export-cli). Works with **Claude Code, Cursor, Copilot, OpenClaw, Codex, Hermes**, and any agent compatible with the [Agent Skills](https://agentskills.io) format.
+
+<p align="center">
+  <img src="assets/microservices-example.png" width="900" alt="Microservices Architecture — generated from a single natural-language prompt">
+</p>
+
+## ✨ Highlights
+
+- **Built-in design system** — 8-category semantic color palette, 5-level font hierarchy, and the 60-30-10 whitespace rule
+- **5 diagram patterns** — Flowchart, Architecture, Sequence, Mind Map, Swimlane — each with dedicated spacing and routing rules
+- **3 arrow routing modes** — straight, L-shaped elbow, and curved waypoint routing for clean connections
+- **Smart CJK-aware sizing** — width auto-derived from label text (`max(160, charCount × 9)`, doubled for CJK) so labels never truncate
+- **Anti-pattern guard rails** — short-arrow label collisions, zone text overlap, spaghetti arrows, container opacity rules — all documented inside SKILL.md so the agent dodges them
+- **200+ community icon libraries** — drop real AWS / Azure / GCP / network / UML / BPMN icons straight into a scene (they're vector, so they render through the export path) via a bundled helper
+- **Two export backends** — `curl` → Kroki API (zero install, SVG) or local Firefox-based CLI (PNG + SVG, works offline)
+- **Render-and-verify loop** — exports a PNG, *views it*, and fixes clipping / overlap / mis-routed arrows before delivery — because you can't judge a diagram from JSON
+- **Iterative review loop** — once the render is clean, shows you the result and applies targeted edits on your feedback, re-exporting until approved (5-round safety valve)
+
+## 🖼️ Examples
+
+> [!TIP]
+> **The hero image above was generated from this single prompt:**
+
+```
+Create a microservices e-commerce architecture with Mobile/Web/Admin clients,
+API Gateway, Auth/User/Order/Product/Payment services, Kafka message queue,
+Notification service, and User DB / Order DB / Product DB / Redis Cache /
+Stripe API
+```
+
+Beyond the architecture hero above, the same skill spans clean box-and-line classics, **real icons pulled from community libraries**, and **hand-drawn sketches** — all from natural language, every one **verified by actually rendering it**:
+
+<table>
+  <tr>
+    <td align="center" width="50%"><b>Flowchart</b><br/>ellipse start/end, diamond decisions, Yes/No branches, elbow routing<br/><img src="assets/flowchart-example.png" width="380" alt="Flowchart — form submission with a Valid? decision branching to Save to DB or Show Errors"></td>
+    <td align="center" width="50%"><b>Sequence</b><br/>participants, dashed lifelines, solid request / dashed response arrows<br/><img src="assets/sequence-example.png" width="380" alt="Sequence diagram — User / API / DB with login, query, rows, token messages"></td>
+  </tr>
+  <tr>
+    <td align="center"><b>Azure web app</b> · <i>community icons</i><br/>real App Service / SQL Database / Blob Storage icons<br/><img src="assets/azure-architecture-example.png" width="380" alt="Azure web app — Users through App Service to SQL Database and Blob Storage, using real Azure icons"></td>
+    <td align="center"><b>GCP data pipeline</b> · <i>community icons</i><br/>Pub/Sub → Dataflow → BigQuery, with a Cloud Storage sink<br/><img src="assets/gcp-pipeline-example.png" width="380" alt="GCP data pipeline — Events through Pub/Sub, Dataflow to BigQuery with a Cloud Storage branch, using real GCP icons"></td>
+  </tr>
+  <tr>
+    <td align="center"><b>Network topology</b> · <i>community icons</i><br/>Cisco-style firewall, router, switch fanning out to hosts<br/><img src="assets/network-topology-example.png" width="380" alt="Office network — Internet through firewall, router and switch to server, client and workstation, using Cisco-style network icons"></td>
+    <td align="center"><b>Hand-drawn</b> · <i>sketch style</i><br/>roughness + Virgil font + hachure fill + emoji icons<br/><img src="assets/hand-drawn-example.png" width="380" alt="Hand-drawn sketch — Idea, Design, Build, Ship boxes in wobbly hand-drawn style with emoji icons"></td>
+  </tr>
+</table>
+
+## 🎨 Design System
+
+Output looks deliberate, not random, because every diagram is built on a consistent design system. Before laying anything out, the skill maps **the relationship in your idea** to a visual *metaphor* — the metaphor drives the diagram's shape more than the type label does:
+
+| Relationship | Visual metaphor | Built with |
+| --- | --- | --- |
+| One → many (broadcast, dispatch) | Fan-out | one node, arrows radiating outward |
+| Many → one (aggregate, merge) | Convergence | several inputs, arrows into one node |
+| Parent → children (hierarchy) | Tree | trunk + branch lines, free-floating text |
+| Repeating cycle (loop, feedback) | Cycle | nodes in a ring, curved arrows back to start |
+| Input → transform → output | Assembly line | left-to-right pipeline of steps |
+| A vs B (comparison) | Side-by-side | two parallel columns on a shared baseline |
+| Before / after, phase break | Gap | whitespace or a dashed divider between groups |
+| Fuzzy / overlapping state | Cloud | overlapping ellipses, no hard borders |
+
+A timeline becomes a baseline + dots; a hierarchy becomes lines + text — structure and typography carry the meaning, so filled boxes are reserved for true components.
+
+<details>
+<summary><b>Palette, spacing, arrows &amp; typography</b> — click to expand</summary>
+
+**Semantic color palette** — 8 categories mapped to meaning: Primary (blue), Success (green), Warning (yellow), Error (red), External (purple), Process (sky), Trigger (orange), Neutral (slate). Follows the **60-30-10 rule**: 60% whitespace, 30% primary accent, 10% highlight.
+
+**Font hierarchy** — Title 28px → Header 24px → Label 20px → Description 16px → Note 14px.
+
+**Smart element sizing** — width auto-derived from the label text: `max(160, charCount × 9)` for Latin, `max(160, charCount × 18)` for CJK — so labels never truncate.
+
+**Spacing system**
+
+| Scenario | Spacing |
+| ---------- | --------- |
+| Labeled arrow gap | 150–200px |
+| Unlabeled arrow gap | 100–120px |
+| Column spacing (labeled) | 400px |
+| Column spacing (unlabeled) | 340px |
+| Zone padding | 50–60px |
+
+**Arrow routing** — straight (default), L-shaped elbow (`points` with right angles), and curved waypoint (`roundness: { type: 2 }`).
+
+**Arrow semantics** — solid = primary flow, dashed = response / async, dotted = optional / weak dependency.
+
+**Anti-pattern guard rails** — zone-text centering traps, cross-zone arrow spaghetti, label collisions on short arrows, and container opacity rules are all documented inside SKILL.md, so the agent dodges them before they happen.
+
+</details>
+
+## 🚀 Installation
+
+### 1. Pick an export backend
+
+| Backend | Install | Output | Notes |
+|---------|---------|--------|-------|
+| **Kroki API** | `curl --version` | SVG | Zero install — pre-installed on macOS / Linux / Git Bash / WSL |
+| **Local CLI** | `npm install -g excalidraw-brute-export-cli && npx playwright install firefox` | PNG + SVG | Required for PNG; runs offline |
+
+<details>
+<summary><b>macOS one-time patch for the local CLI</b> — click to expand</summary>
+
+The CLI presses `Control+O` / `Control+Shift+E`, but macOS needs `Meta` (Cmd). Apply once after installing the CLI (Windows and Linux need no extra step):
+
+```bash
+CLI_MAIN=$(npm root -g)/excalidraw-brute-export-cli/src/main.js
+sed -i '' 's/keyboard.press("Control+O")/keyboard.press("Meta+O")/' "$CLI_MAIN"
+sed -i '' 's/keyboard.press("Control+Shift+E")/keyboard.press("Meta+Shift+E")/' "$CLI_MAIN"
+```
+
+</details>
+
+### 2. Install the skill
+
+```bash
+# Any agent (Claude Code, Cursor, Copilot, ...)
+npx skills add Agents365-ai/365-skills -g
+```
+
+```text
+# Claude Code plugin marketplace
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install excalidraw
+```
+
+```bash
+# Manual install
+git clone https://github.com/Agents365-ai/excalidraw-skill.git \
+  ~/.claude/skills/excalidraw-skill
+```
+
+Also indexed on [SkillsMP](https://skillsmp.com/skills/agents365-ai-excalidraw-skill-skills-excalidraw-skill-skill-md) and [ClawHub](https://clawhub.ai/agents365-ai/excalidraw-skill).
+
+## ⚡ Quick Start
+
+After installation, just describe what you want — for example, a system design sketch:
+
+```
+Sketch a CI/CD pipeline for a Python web app: developer pushes to GitHub,
+triggers GitHub Actions running lint, unit tests, and a security scan in
+parallel, then builds a Docker image, pushes to GHCR, and deploys to staging
+via ArgoCD with a manual promotion gate to production.
+```
+
+The skill picks the right diagram pattern, applies the semantic palette, sizes shapes from the labels, routes the arrows, writes the `.excalidraw` JSON file, and exports to your chosen format.
+
+## 🧩 Supported Diagram Types
+
+| Pattern | Examples | Notable rules |
+| --- | --- | --- |
+| Architecture | microservices, cloud stacks, network topology, deployment | Column spacing 340–400px, dashed `Neutral` zones at opacity 25–40 |
+| Flowchart | business processes, decision trees, state machines | Ellipse start/end, diamond decisions, "Yes" forward / "No" down |
+| Sequence | API call flows, RPC traces | 200px between participants, dashed lifelines, dashed = response |
+| Mind Map | brainstorms, topic breakdowns | Radial layout, 4 size tiers (200→90px) by depth, lines (not arrows) |
+| Swimlane | cross-team handoffs, multi-actor processes | Transparent dashed lanes, free-standing 28px lane labels, LR flow |
+
+Each pattern's full spacing/routing rules and anti-patterns live in [`SKILL.md`](skills/excalidraw-skill/SKILL.md).
+
+## 🧩 Real icons from community libraries
+
+Plain boxes not enough? The [Excalidraw community libraries](https://libraries.excalidraw.com) (200+ `.excalidrawlib` files — AWS, Azure, GCP, network topology, C4, BPMN, UML, circuits…) are built from the **same vector primitives** this skill exports, so their icons **render through Kroki and the local CLI** — no `image` element, no `files` map. A bundled helper (`scripts/excalidraw_lib.py`) finds a library, lists its items, and merges one into your scene with IDs namespaced and coordinates translated:
+
+```bash
+python scripts/excalidraw_lib.py search aws
+python scripts/excalidraw_lib.py merge scene.excalidraw \
+    slobodan/aws-serverless.excalidrawlib 0 455 257 --scale 0.9 --prefix lambda
+```
+
+<p align="center">
+  <img src="assets/library-icons-example.png" width="760" alt="Serverless request flow — Web/Mobile client through real AWS CloudFront, Lambda, DynamoDB and S3 icons embedded from the Excalidraw community library">
+</p>
+
+> The diagram above embeds real AWS icons (CloudFront, Lambda, DynamoDB, S3) pulled straight from a community library — then render-verified like everything else.
+
+## 🔄 How it works
+
+<p align="center">
+  <img src="assets/workflow-example.png" width="900" alt="Skill pipeline — Detect → Plan → Generate → Export → Verify → Report, with a dashed feedback loop from Verify back to Generate (fix & re-export until clean). This diagram was itself drawn and render-verified by the skill.">
+</p>
+
+> The pipeline diagram above was drawn by the skill itself and passed through the same render-and-verify loop it documents.
+
+1. **Detect dependency** — `curl` (Kroki) or local `excalidraw-brute-export-cli`
+2. **Plan** — identify diagram type, pick the matching pattern, choose semantic colors
+3. **Generate** — write the `.excalidraw` JSON (section-by-section for 10+ elements; namespaced seeds prevent collisions)
+4. **Export** — `curl` to Kroki for SVG, or local CLI for PNG / SVG at 1x–3x scale
+5. **Verify the render** — export a PNG, *view it*, fix any clipping / overlap / arrow-through-shape, then re-export (1–3 passes)
+6. **Review loop** — show you the result, apply targeted edits on your feedback, re-export until approved (5-round safety valve)
+7. **Report** — return the output file path
+
+No MCP server and no background daemon — the design system does the heavy lifting up-front, then a quick render-and-verify pass (export PNG → view → fix) catches what JSON alone can't show.
+
+## 🤔 Why a skill, not an MCP server?
+
+Excalidraw's format is just an array of elements with x/y/width/height — Claude can write it natively. A skill teaches Claude *how* to draw; an MCP server gives Claude *a tool* to draw. When the model can do the job itself, teaching beats tooling — no service to run, no runtime to install, and the model keeps full semantic control over layout.
+
+| Aspect | Skill (this) | MCP Server |
+| -------- | -------------- | ------------ |
+| How it works | Prompt injected into context | Separate running service |
+| Generation | Claude writes JSON directly | Code handles JSON generation |
+| Flexibility | Free-form, semantic layout | Fixed API parameters |
+| Install | Copy one file | Start a service, configure MCP |
+| Dependencies | Zero | Node.js / Python runtime |
+
+MCP earns its keep when Claude needs capabilities it *can't* do alone — database access, browser automation, authenticated APIs. Diagram generation is design + JSON writing, which is exactly what LLMs are good at.
+
+## 🆚 Comparison
+
+### vs Native Agent (no skill)
+
+| Feature | Native agent | excalidraw-skill |
+| --- | --- | --- |
+| Valid `.excalidraw` JSON | ❌ usually invalid / non-interactive | ✅ valid schema, full arrow binding |
+| Semantic color palette | random / inconsistent | ✅ 8-category palette + 60-30-10 rule |
+| Font hierarchy | ad-hoc | ✅ 5-level (28 / 24 / 20 / 16 / 14) |
+| Diagram-type presets | ❌ | ✅ 5 patterns with dedicated spacing |
+| CJK-aware shape sizing | ❌ truncates Chinese labels | ✅ doubled width for CJK characters |
+| Anti-pattern guard rails | ❌ | ✅ zone overlap, spaghetti arrows, label collisions documented |
+| One-shot PNG / SVG export | ❌ manual ask | ✅ via Kroki (`curl`) or local CLI |
+| Editable output in excalidraw.com | partial | ✅ preserves arrow binding |
+| Self-check + review loop | ❌ never looks at the render | ✅ views the PNG, fixes defects, then iterates on your feedback (≤5 rounds) |
+
+### vs Other Excalidraw Skills
+
+The Excalidraw-skill space is crowded. The largest skills — **[coleam00/excalidraw-diagram-skill](https://github.com/coleam00/excalidraw-diagram-skill)** (~3.4k★) and **[yctimlin/mcp_excalidraw](https://github.com/yctimlin/mcp_excalidraw)** (~2k★) — pioneered the render-and-verify loop; this skill adopts it (v1.2.0) while staying zero-install and tuned for the lightweight export path.
+
+| | **excalidraw-skill** (this) | coleam00 (~3.4k★) | mcp_excalidraw (~2k★) | Most others |
+| --- | --- | --- | --- | --- |
+| Install footprint | **Zero-install** via Kroki (`curl`); Firefox CLI only for PNG | `uv` + Playwright **Chromium** | Node **MCP server** | varies |
+| Runs beyond Claude Code | ✅ any [Agent Skills](https://agentskills.io) agent (Cursor, Copilot, Codex…) | Claude Code | MCP clients | mostly Claude Code |
+| Render → view → fix loop | ✅ (v1.2.0) | ✅ (pioneered) | ✅ live canvas | ✗ usually |
+| Static-export tuning (edge-to-edge endpoints, arrow-label masking) | ✅ documented & verified | n/a — renders real Excalidraw | n/a — live canvas | ✗ (some advise center-to-center) |
+| CJK-aware sizing + bilingual triggers | ✅ | ✗ | ✗ | ✗ |
+| Semantic design system (palette, spacing, font tiers) | ✅ | ✅ | partial | varies |
+| Output | `.excalidraw` + PNG / SVG | PNG | live canvas + export | varies |
+
+**Where each wins:** coleam00 is the most polished single-diagram generator (Chromium render = pixel-faithful); mcp_excalidraw shines for live, interactive canvas editing. Reach for **this** skill when you want **no heavy runtime** (just `curl`), use **an agent other than Claude Code**, need **bilingual / CJK** diagrams, or want correct output through the **Kroki / CLI export path** that most skills don't account for.
+
+## 🎯 When to use (and when not to)
+
+**Good fit:**
+
+- Hand-drawn / sketchy diagrams — wireframes, mockups, brainstorms, informal architecture
+- A friendly, low-fidelity "draft, not final" look (hand-drawn fills, arrows, text)
+- Visuals where approachable personality matters more than precision
+
+**Reach for a sibling skill instead when you need:**
+
+- **Polished, precise diagrams, strict UML, or branded vendor icons** → [drawio-skill](https://github.com/Agents365-ai/drawio-skill)
+- **Diagrams-as-code in git, auto-laid-out from text** → [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill) (general) or [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill) (UML)
+- **An infinite-canvas whiteboard or programmatic freehand strokes** → [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+
+## 🔗 Related Skills
+
+Part of the [Agents365-ai diagram-skill family](https://github.com/Agents365-ai) — pick the right tool for the job:
+
+| Skill | Style | Best for |
+| --- | --- | --- |
+| [drawio-skill](https://github.com/Agents365-ai/drawio-skill) | Polished, presentation-ready | Architecture, UML, ML/DL diagrams, formal docs |
+| [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill) | Text-based, auto-layout | README-embeddable, version-control friendly |
+| [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill) | UML-focused | Class / sequence diagrams in CI pipelines |
+| [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill) | Whiteboard collaboration | Casual sketches, FigJam-style boards |
+
+## ❤️ Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="Give a Reward">
+      <br>
+      <b>Give a Reward</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 Author
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/plugins/excalidraw/README_CN.md
+++ b/plugins/excalidraw/README_CN.md
@@ -1,0 +1,315 @@
+# excalidraw-skill —— 自然语言生成简洁 / 手绘风格图表
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/excalidraw-skill?style=flat&logo=github&cacheSeconds=86400)](https://github.com/Agents365-ai/excalidraw-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/excalidraw-skill?style=flat&logo=github&cacheSeconds=86400)](https://github.com/Agents365-ai/excalidraw-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/excalidraw-skill?logo=github&cacheSeconds=86400)](https://github.com/Agents365-ai/excalidraw-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/excalidraw-skill?logo=github&cacheSeconds=3600)](https://github.com/Agents365-ai/excalidraw-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-excalidraw-skill-skills-excalidraw-skill-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/excalidraw-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-兼容-2ea44f)](https://agentskills.io)
+[English](README.md) · **中文** · [📖 在线文档](https://agents365-ai.github.io/excalidraw-skill/zh.html)
+
+一个把自然语言描述变成简洁、专业的 `.excalidraw` JSON(需要时也能出手绘风格草图),并导出为 PNG / SVG 的技能 —— 既可走零安装的 [Kroki](https://kroki.io) API,也可走本地 [`excalidraw-brute-export-cli`](https://www.npmjs.com/package/excalidraw-brute-export-cli)。支持 **Claude Code、Cursor、Copilot、OpenClaw、Codex、Hermes** 等任何兼容 [Agent Skills](https://agentskills.io) 规范的 agent。
+
+<p align="center">
+  <img src="assets/microservices-example.png" width="900" alt="微服务架构图 —— 来自一条自然语言提示词">
+</p>
+
+## ✨ 核心亮点
+
+- **内置设计体系** —— 8 类语义配色、5 级字号层级,遵循 60-30-10 留白法则
+- **5 种图表模式** —— 流程图、架构图、时序图、思维导图、泳道图,每种都有专属布局与间距规则
+- **3 种箭头路由** —— 直线、L 形折线、曲线 waypoint,连线干净不打结
+- **CJK 智能尺寸** —— 按标签自动算宽度(`max(160, charCount × 9)`,CJK 字符翻倍),标签不再被截
+- **反模式防护** —— 短箭头标签碰撞、区域文字重叠、面条箭头、容器透明度等坑都在 SKILL.md 中提前避开
+- **200+ 社区图标库** —— 把真实的 AWS / Azure / GCP / 网络 / UML / BPMN 图标直接放进图里(它们是矢量的,能走导出路径渲染),由内置脚本一键嵌入
+- **两种导出后端** —— `curl` 走 Kroki(零安装,SVG)或本地 Firefox CLI(PNG + SVG,可离线)
+- **渲染自检循环** —— 导出 PNG 后*真的看一眼*,修掉文字截断 / 元素重叠 / 箭头穿模再交付 —— 因为光看 JSON 判断不了一张图
+- **迭代评审循环** —— 渲染干净后,把结果给你看,按你的反馈做定向编辑、重新导出,直到满意(5 轮安全阀)
+
+## 🖼️ 示例
+
+> [!TIP]
+> **页首那张图就是用下面这条提示词生成的:**
+
+```
+画一个微服务电商架构图,包含 Mobile/Web/Admin 客户端,API Gateway,
+Auth/User/Order/Product/Payment 微服务,Kafka 消息队列,Notification 服务,
+User DB / Order DB / Product DB / Redis Cache / Stripe API
+```
+
+除了页首那张架构图,同一个技能从简洁框线图、到**社区库里的真实图标**、再到**手绘草图**都能画 —— 全部来自自然语言,且**每张都经过真实渲染验证**:
+
+<table>
+  <tr>
+    <td align="center" width="50%"><b>流程图</b><br/>椭圆起止、菱形判断、Yes/No 分支、直角折线<br/><img src="assets/flowchart-example.png" width="380" alt="流程图 —— 表单提交,Valid? 判断分流到 Save to DB 或 Show Errors"></td>
+    <td align="center" width="50%"><b>时序图</b><br/>参与者、虚线生命线、实线请求 / 虚线响应<br/><img src="assets/sequence-example.png" width="380" alt="时序图 —— User / API / DB 的 login、query、rows、token 消息"></td>
+  </tr>
+  <tr>
+    <td align="center"><b>Azure Web 应用</b> · <i>社区图标</i><br/>真实的 App Service / SQL Database / Blob Storage 图标<br/><img src="assets/azure-architecture-example.png" width="380" alt="Azure Web 应用 —— Users 经 App Service 到 SQL Database 与 Blob Storage,使用真实 Azure 图标"></td>
+    <td align="center"><b>GCP 数据管道</b> · <i>社区图标</i><br/>Pub/Sub → Dataflow → BigQuery,旁挂 Cloud Storage<br/><img src="assets/gcp-pipeline-example.png" width="380" alt="GCP 数据管道 —— Events 经 Pub/Sub、Dataflow 到 BigQuery,旁挂 Cloud Storage,使用真实 GCP 图标"></td>
+  </tr>
+  <tr>
+    <td align="center"><b>网络拓扑</b> · <i>社区图标</i><br/>Cisco 风格防火墙、路由器、交换机,扇出到主机<br/><img src="assets/network-topology-example.png" width="380" alt="办公网络 —— Internet 经防火墙、路由器、交换机到服务器、客户端、工作站,使用 Cisco 风格网络图标"></td>
+    <td align="center"><b>手绘风</b> · <i>草图风格</i><br/>roughness + Virgil 字体 + 斜线填充 + emoji 图标<br/><img src="assets/hand-drawn-example.png" width="380" alt="手绘草图 —— Idea、Design、Build、Ship 方框,抖动手绘风格,带 emoji 图标"></td>
+  </tr>
+</table>
+
+## 🎨 设计体系
+
+图看起来是经过设计的、而非随机堆砌的,因为每张图都建立在一套统一的设计体系上。在排布之前,技能会先把**你描述里的关系**映射到一个可视化*隐喻* —— 隐喻比类型标签更能决定一张图的形状:
+
+| 关系 | 可视化隐喻 | 用什么搭 |
+| --- | --- | --- |
+| 一对多(广播、分发) | 扇出 Fan-out | 一个节点,箭头向外辐射 |
+| 多对一(聚合、汇流) | 汇聚 Convergence | 多个输入,箭头汇入一个节点 |
+| 父对子(层级) | 树 Tree | 主干 + 分支线,自由文字 |
+| 循环往复(回路、反馈) | 环 Cycle | 节点成环,曲线箭头回到起点 |
+| 输入 → 变换 → 输出 | 流水线 Assembly line | 从左到右的步骤管道 |
+| A 对 B(对比) | 并排 Side-by-side | 共享基线的两列并排 |
+| 前后 / 阶段切换 | 留白 Gap | 用空白或虚线分隔分组 |
+| 模糊 / 重叠状态 | 云 Cloud | 重叠椭圆,无硬边界 |
+
+时间线 = 基准线 + 圆点,层级 = 线 + 文字 —— 结构和排版本身承载含义,方框只留给真正的组件。
+
+<details>
+<summary><b>配色、间距、箭头与字体</b> —— 点击展开</summary>
+
+**语义配色** —— 8 类映射到含义:主要(蓝)、成功(绿)、警告(黄)、错误(红)、外部(紫)、流程(天蓝)、触发(橙)、中性(灰蓝)。遵循 **60-30-10 法则**:60% 留白、30% 主色调、10% 强调色。
+
+**字体层次** —— 标题 28px → 组标题 24px → 标签 20px → 描述 16px → 注释 14px。
+
+**智能尺寸** —— 按标签文字自动算宽度:西文 `max(160, charCount × 9)`,CJK `max(160, charCount × 18)` —— 标签不再被截。
+
+**间距体系**
+
+| 场景 | 间距 |
+| ------ | ------ |
+| 有标签箭头间距 | 150–200px |
+| 无标签箭头间距 | 100–120px |
+| 列间距(有标签) | 400px |
+| 列间距(无标签) | 340px |
+| 区域内边距 | 50–60px |
+
+**箭头路由** —— 直线(默认)、L 形折线(`points` 直角转折)、曲线弯折(`roundness: { type: 2 }`)。
+
+**箭头语义** —— 实线 = 主流程,虚线 = 响应 / 异步,点线 = 可选 / 弱依赖。
+
+**反模式防护** —— 区域文字居中重叠、跨区域箭头面条化、短箭头标签碰撞、容器透明度规则,都写在 SKILL.md 里,让 agent 在生成前就规避。
+
+</details>
+
+## 🚀 安装
+
+### 1. 选一个导出后端
+
+| 后端 | 安装命令 | 输出 | 备注 |
+|------|----------|------|------|
+| **Kroki API** | `curl --version` | SVG | 零安装 —— macOS / Linux / Git Bash / WSL 默认自带 |
+| **本地 CLI** | `npm install -g excalidraw-brute-export-cli && npx playwright install firefox` | PNG + SVG | PNG 必需;支持离线 |
+
+<details>
+<summary><b>macOS 本地 CLI 一次性补丁</b> —— 点击展开</summary>
+
+CLI 按的是 `Control+O` / `Control+Shift+E`,但 macOS 需要 `Meta`(Cmd)键。装好 CLI 后执行一次即可(Windows、Linux 无需额外步骤):
+
+```bash
+CLI_MAIN=$(npm root -g)/excalidraw-brute-export-cli/src/main.js
+sed -i '' 's/keyboard.press("Control+O")/keyboard.press("Meta+O")/' "$CLI_MAIN"
+sed -i '' 's/keyboard.press("Control+Shift+E")/keyboard.press("Meta+Shift+E")/' "$CLI_MAIN"
+```
+
+</details>
+
+### 2. 安装技能
+
+```bash
+# 任意 Agent(Claude Code、Cursor、Copilot 等)
+npx skills add Agents365-ai/365-skills -g
+```
+
+```text
+# Claude Code 插件市场
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install excalidraw
+```
+
+```bash
+# 手动安装
+git clone https://github.com/Agents365-ai/excalidraw-skill.git \
+  ~/.claude/skills/excalidraw-skill
+```
+
+同时索引于 [SkillsMP](https://skillsmp.com/skills/agents365-ai-excalidraw-skill-skills-excalidraw-skill-skill-md) 与 [ClawHub](https://clawhub.ai/agents365-ai/excalidraw-skill)。
+
+## ⚡ 快速开始
+
+装好之后直接描述你想要的图表,例如一张系统设计草图:
+
+```
+画一个 Python Web 应用的 CI/CD 流水线:开发者 push 到 GitHub 后触发
+GitHub Actions,并行跑 lint、单元测试、安全扫描,然后构建 Docker 镜像
+推送到 GHCR,通过 ArgoCD 部署到 staging,再走人工审批门发布到 production。
+```
+
+Skill 会自动选择图表模式、套用语义配色、按标签计算尺寸、规划箭头路由、写出 `.excalidraw` JSON,并导出为你指定的格式。
+
+## 🧩 支持的图表类型
+
+| 模式 | 示例 | 关键规则 |
+| ------ | ------ | --------- |
+| 架构图 | 微服务、云栈、网络拓扑、部署 | 列间距 340–400px,虚线 `Neutral` 区域透明度 25–40 |
+| 流程图 | 业务流程、决策树、状态机 | 椭圆 start/end、菱形判断,"Yes" 前进 / "No" 下行 |
+| 时序图 | API 调用、RPC 跟踪 | 参与者间距 200px,虚线生命线,虚线 = 响应 |
+| 思维导图 | 头脑风暴、主题拆解 | 辐射布局,4 级尺寸(200→90px)按深度递减,用 line 而非 arrow |
+| 泳道图 | 跨团队交接、多角色流程 | 透明虚线泳道,28px 独立泳道标签,从左到右流动 |
+
+各模式完整的间距 / 路由规则与反模式列表见 [`SKILL.md`](skills/excalidraw-skill/SKILL.md)。
+
+## 🧩 用社区库里的真实图标
+
+光有方框不够?[Excalidraw 社区库](https://libraries.excalidraw.com)(200+ 个 `.excalidrawlib` —— AWS、Azure、GCP、网络拓扑、C4、BPMN、UML、电路……)本质上就是用这个 skill 所导出的**同一批矢量原语**拼的,所以它们的图标**能走 Kroki / 本地 CLI 渲染** —— 没有 `image` 元素、不需要 `files` 映射。内置脚本(`scripts/excalidraw_lib.py`)负责搜库、列 item,并把某个 item 并入你的场景(ID 命名空间化、坐标平移):
+
+```bash
+python scripts/excalidraw_lib.py search aws
+python scripts/excalidraw_lib.py merge scene.excalidraw \
+    slobodan/aws-serverless.excalidrawlib 0 455 257 --scale 0.9 --prefix lambda
+```
+
+<p align="center">
+  <img src="assets/library-icons-example.png" width="760" alt="Serverless 请求流 —— Web/Mobile 客户端经过从 Excalidraw 社区库嵌入的真实 AWS CloudFront、Lambda、DynamoDB、S3 图标">
+</p>
+
+> 上图嵌入了从社区库直接取来的真实 AWS 图标(CloudFront、Lambda、DynamoDB、S3),并和其他图一样经过了渲染自检。
+
+## 🔄 工作流程
+
+<p align="center">
+  <img src="assets/workflow-example.png" width="900" alt="技能流水线 —— 检测 → 规划 → 生成 → 导出 → 自检 → 回报,带一条从「自检」回到「生成」的虚线反馈回路(修正并重新导出,直到干净)。这张图本身就是用该技能画出并经渲染自检验证的。">
+</p>
+
+> 上面这张流水线图就是技能自己画的,而且走了它所记录的同一套渲染自检循环。
+
+1. **检测依赖** —— `curl`(Kroki)或本地 `excalidraw-brute-export-cli`
+2. **规划** —— 识别图表类型,选模式,挑语义配色
+3. **生成** —— 写出 `.excalidraw` JSON(10+ 元素时按段拼接,seed 命名空间避免冲突)
+4. **导出** —— `curl` 走 Kroki 出 SVG,或本地 CLI 出 1x–3x PNG / SVG
+5. **渲染自检** —— 导出 PNG 后*真的看一眼*,修掉文字截断 / 重叠 / 箭头穿模,再重新导出(1–3 轮)
+6. **评审循环** —— 把结果给你看,按你的反馈做定向编辑、重新导出,直到满意(5 轮安全阀)
+7. **回报** —— 返回输出文件路径
+
+没有 MCP server、没有后台 daemon —— 设计体系在生成前把住大头,再用一轮渲染自检(导出 PNG → 查看 → 修正)兜住 JSON 看不出来的问题。
+
+## 🤔 为什么用 Skill 而不是 MCP?
+
+Excalidraw 的格式就是一个元素数组,每个元素有 x/y/width/height —— Claude 天然就能写。Skill 教 Claude「怎么画」,MCP 给 Claude「一个画笔」。当模型自己就能画时,教它怎么画胜过给它工具:没有服务要起、没有运行时要装,模型还能完整掌控布局语义。
+
+| 维度 | Skill(本技能) | MCP Server |
+| ------ | ---------------- | ------------ |
+| 原理 | 提示词注入到上下文 | 独立运行的服务进程 |
+| 生成方式 | Claude 直接写 JSON | 需要代码处理 JSON 生成 |
+| 灵活性 | 自由布局,理解语义 | API 参数固定 |
+| 安装 | 复制一个文件 | 启动服务、配置 MCP |
+| 依赖 | 零 | Node.js / Python 运行时 |
+
+MCP 的价值在于提供 Claude **自身做不到的能力** —— 数据库访问、浏览器自动化、带认证的 API。图表生成的核心是 设计布局 + 写 JSON,恰恰是 LLM 最擅长的。
+
+## 🆚 对比
+
+### 对比原生智能体(无 skill)
+
+| 功能 | 原生智能体 | excalidraw-skill |
+| ------ | ----------- | ------------------ |
+| 合法 `.excalidraw` JSON | ❌ 常常无效 / 不可交互 | ✅ 合法 schema,箭头绑定完整 |
+| 语义配色 | 随机 / 不一致 | ✅ 8 类调色板 + 60-30-10 法则 |
+| 字号层级 | 临场拍脑袋 | ✅ 5 级(28 / 24 / 20 / 16 / 14) |
+| 图表类型预设 | ❌ | ✅ 5 种模式,各有专属间距 |
+| CJK 尺寸适配 | ❌ 中文标签被截 | ✅ CJK 字符宽度翻倍 |
+| 反模式防护 | ❌ | ✅ 区域重叠、面条箭头、标签碰撞均有文档 |
+| 一键导出 PNG / SVG | ❌ 需手动追问 | ✅ Kroki(`curl`)或本地 CLI |
+| excalidraw.com 中可编辑 | 部分 | ✅ 箭头绑定完整保留 |
+| 自检 + 评审循环 | ❌ 从不看渲染结果 | ✅ 看 PNG、修缺陷,再按反馈迭代(≤5 轮) |
+
+### 对比其他 Excalidraw skill
+
+Excalidraw skill 赛道很挤。星标最高的两个 —— **[coleam00/excalidraw-diagram-skill](https://github.com/coleam00/excalidraw-diagram-skill)**(~3.4k★)和 **[yctimlin/mcp_excalidraw](https://github.com/yctimlin/mcp_excalidraw)**(~2k★)—— 率先做了「渲染自检循环」;本技能在 v1.2.0 也引入了它,同时保持零安装、并针对轻量导出路径做了适配。
+
+| | **本技能** | coleam00(~3.4k★) | mcp_excalidraw(~2k★) | 多数其他 |
+| --- | --- | --- | --- | --- |
+| 安装负担 | **零安装** 走 Kroki(`curl`);仅 PNG 才需 Firefox CLI | `uv` + Playwright **Chromium** | Node **MCP 服务进程** | 各异 |
+| 是否限于 Claude Code | ✅ 任意 [Agent Skills](https://agentskills.io) agent(Cursor、Copilot、Codex…) | Claude Code | MCP 客户端 | 多数仅 Claude Code |
+| 渲染 → 查看 → 修正循环 | ✅(v1.2.0) | ✅(首创) | ✅ 实时画布 | ✗ 通常没有 |
+| 静态导出适配(端到端端点、箭头标签遮罩) | ✅ 有文档且经验证 | 不涉及 —— 渲染真实 Excalidraw | 不涉及 —— 实时画布 | ✗(部分还建议中心到中心) |
+| CJK 尺寸适配 + 双语触发 | ✅ | ✗ | ✗ | ✗ |
+| 语义设计体系(配色、间距、字号层级) | ✅ | ✅ | 部分 | 各异 |
+| 输出 | `.excalidraw` + PNG / SVG | PNG | 实时画布 + 导出 | 各异 |
+
+**各自的强项:** coleam00 是单图生成最精致的(Chromium 渲染 = 像素级还原);mcp_excalidraw 适合实时、可交互的画布编辑。选**本技能**的理由:不想要重运行时(只需 `curl`)、用的是 **Claude Code 以外的 agent**、需要**双语 / 中文**图表,或想要在多数 skill 没适配的 **Kroki / CLI 导出路径**下也输出正确。
+
+## 🎯 何时用(以及何时别用)
+
+**适合:**
+
+- 手绘 / 潦草风格的图 —— 线框图、原型、头脑风暴、非正式架构图
+- 亲和、低保真的"草稿,非最终稿"观感(手绘填充、箭头、文字)
+- 比起精确度,更看重亲和力与个性的可视化
+
+**这些情况请改用同系列的其它 skill:**
+
+- **精致、精确的图,严格 UML,或品牌厂商图标** → [drawio-skill](https://github.com/Agents365-ai/drawio-skill)
+- **以代码形式存进 git、从文本自动布局的图** → [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill)(通用)或 [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill)(UML)
+- **无限画布白板或程序化自由笔迹** → [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+
+## 🔗 相关 Skill
+
+[Agents365-ai 图表 skill 家族](https://github.com/Agents365-ai) 一员 —— 按场景挑工具:
+
+| Skill | 风格 | 适用场景 |
+| --- | --- | --- |
+| [drawio-skill](https://github.com/Agents365-ai/drawio-skill) | 精修、汇报级 | 架构图、UML、ML/DL 图、正式文档 |
+| [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill) | 文本驱动、自动布局 | 可嵌入 README、易于版本管理 |
+| [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill) | UML 专精 | CI 流水线里的类图 / 序列图 |
+| [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill) | 白板协作 | 随手画、FigJam 风格 |
+
+## ❤️ 支持作者
+
+如果这个 skill 对你有帮助,欢迎支持作者:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="打赏">
+      <br>
+      <b>打赏</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 作者
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 许可证
+
+[MIT](LICENSE)

--- a/plugins/mermaid/LICENSE
+++ b/plugins/mermaid/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/mermaid/README.md
+++ b/plugins/mermaid/README.md
@@ -1,0 +1,206 @@
+# mermaid-skill — From Code to Image, Automatically
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/mermaid-skill?style=flat&logo=github)](https://github.com/Agents365-ai/mermaid-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/mermaid-skill?style=flat&logo=github)](https://github.com/Agents365-ai/mermaid-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/mermaid-skill?logo=github)](https://github.com/Agents365-ai/mermaid-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/mermaid-skill?logo=github)](https://github.com/Agents365-ai/mermaid-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-mermaid-skill-skills-mermaid-skill-skill-md)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+**English** · [中文](README_CN.md) · [📖 Online Docs](https://agents365-ai.github.io/mermaid-skill/)
+
+A skill that turns natural-language requests into `.mmd` source, validates syntax before export, and renders to PNG / SVG / PDF via the `mmdc` CLI or the Kroki HTTP API. Works with any agent compatible with the [Agent Skills](https://agentskills.io) format.
+
+<p align="center">
+  <img src="assets/example.png" width="900" alt="Microservices architecture — generated from a single natural-language prompt">
+</p>
+
+## ✨ Highlights
+
+- **17+ diagram types** — flowchart, sequence, class, ER, state, Gantt, pie, git graph, C4 context, mind map, and more, all with automatic layout (no x/y coordinates)
+- **Validation-first workflow** — every `.mmd` is parsed before export, so broken syntax never leaks into a PNG (Kroki-first validation needs no browser; Chrome is only required for local export)
+- **Mermaid.live handoff** — every review loop ends with a one-click link that opens the current diagram in the [mermaid.live](https://mermaid.live) editor for interactive fine-tuning
+- **Vision self-check + review loop** — reads the exported PNG to catch readability/layout defects auto-layout can't prevent (clipped labels, cramped density, wrong orientation), auto-fixes (≤2 rounds), then iterates with you on feedback (≤5 rounds)
+- **Two backends, one skill** — local `mmdc` for best quality, Kroki HTTP API as zero-install fallback (only `curl` required)
+- **Text source = version-control friendly** — `.mmd` is plain text, diffs cleanly in PRs, and embeds directly in GitHub / GitLab READMEs
+- **Proactive triggering** — auto-activates when discussing architecture, API flows, or state machines (English + Chinese keywords)
+- **Multi-agent, zero-config** — one SKILL.md, no MCP server, no background daemon (the optional `npx` installer needs Node, the skill itself does not)
+- **Batch mode** — survey a whole repo and generate a diagram suite (ER + sequence + state + flowchart) plus a self-contained HTML overview page
+- **CI/Docker ready** — bundled `puppeteer-config.json` for `--no-sandbox` container exports
+
+## 🖼️ Examples
+
+> [!TIP]
+> **The hero image above was generated from this single prompt:**
+
+```
+Create a microservices e-commerce architecture with Mobile/Web clients,
+API Gateway, User/Order/Product/Payment services, and User DB / Order DB /
+Product DB / Redis Cache
+```
+
+### More diagram types
+
+Mermaid auto-lays-out 17+ types — each of these was generated from a one-line prompt and run through the validate → export → self-check pipeline:
+
+<table>
+  <tr>
+    <td align="center"><img src="assets/example-sequence.png" width="260" alt="OAuth login sequence diagram"><br><sub><b>Sequence</b> · auth flow</sub></td>
+    <td align="center"><img src="assets/example-class.png" width="140" alt="Blog domain class diagram"><br><sub><b>Class</b> · domain model</sub></td>
+    <td align="center"><img src="assets/example-state.png" width="150" alt="Order lifecycle state machine"><br><sub><b>State</b> · order lifecycle</sub></td>
+  </tr>
+  <tr>
+    <td align="center"><img src="assets/example-er.png" width="240" alt="E-commerce ER diagram"><br><sub><b>ER</b> · e-commerce schema</sub></td>
+    <td align="center"><img src="assets/example-gantt.png" width="300" alt="Product launch Gantt chart"><br><sub><b>Gantt</b> · launch plan</sub></td>
+    <td align="center"><img src="assets/example-gitgraph.png" width="300" alt="Git branching strategy graph"><br><sub><b>Git graph</b> · branch strategy</sub></td>
+  </tr>
+</table>
+
+Full feature matrix in [docs/features.md](docs/features.md). Source `.mmd` files for the hero, workflow, and gallery images live alongside their PNGs in [`assets/`](assets/) (`example-{sequence,class,state,er,gantt,gitgraph}.mmd`).
+
+## 🚀 Installation
+
+### 1. Pick an export backend
+
+| Option | Command | When to use |
+| --- | --- | --- |
+| **A — Local `mmdc`** | `npm install -g @mermaid-js/mermaid-cli && mmdc --version` | Best quality, full theme control, offline use |
+| **B — Kroki API** | `curl --version` | No install, no Node, CI/CD pipelines |
+
+The skill probes `mmdc` first and falls back to Kroki automatically.
+
+### 2. Install the skill
+
+```bash
+# Any agent (Claude Code, Cursor, Copilot, ...)
+npx skills add Agents365-ai/365-skills -g
+```
+
+```text
+# Claude Code plugin marketplace
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install mermaid
+```
+
+```bash
+# Manual install
+git clone https://github.com/Agents365-ai/mermaid-skill.git \
+  ~/.claude/skills/mermaid-skill
+```
+
+Also indexed on [SkillsMP](https://skillsmp.com/skills/agents365-ai-mermaid-skill-skills-mermaid-skill-skill-md).
+
+**Updating:** `/plugin update mermaid` (Claude Code), `skills update mermaid-skill` (SkillsMP), or `git pull` for manual installs.
+
+## ⚡ Quick Start
+
+After installation, just describe what you want — e.g. a JWT auth sequence:
+
+```
+Create a sequence diagram for JWT login: Client posts credentials to API
+Gateway, gateway calls Auth Service, Auth Service reads the User DB,
+verifies the password hash, and returns a signed JWT back through the
+gateway to the client. Show the failure path for an invalid password too.
+```
+
+The skill picks the diagram type, writes the `.mmd` source, validates with `mmdc` (or Kroki), exports to your chosen format, and reports the output paths.
+
+## 🧩 Supported Diagram Types
+
+| Type | Keyword | Use for |
+| --- | --- | --- |
+| Flowchart | `flowchart TD/LR` | processes, pipelines, decision trees |
+| Sequence | `sequenceDiagram` | API calls, auth flows, message passing |
+| Class | `classDiagram` | OOP models, domain entities, inheritance |
+| ER | `erDiagram` | database schemas, relationships |
+| State | `stateDiagram-v2` | state machines, lifecycles |
+| Gantt | `gantt` | project timelines, sprint plans |
+| Pie | `pie` | proportions, distributions |
+| Git Graph | `gitGraph` | branch strategies, GitFlow |
+| C4 Context | `C4Context` | high-level architecture |
+| Architecture | `architecture-beta` | cloud / CI-CD service layouts |
+| Mind Map | `mindmap` | topic breakdowns, brainstorms |
+| Journey | `journey` | user journeys |
+| Use Case | `usecase-beta` | actor–system interactions (UML) |
+| Cynefin | `cynefin-beta` | sense-making / complexity domains |
+| Event Modeling | `eventmodeling` | event-driven system timelines |
+| Tree View | `treeView-beta` | file / directory hierarchies |
+| Wardley Maps | `wardley-beta` | business strategy / value chains |
+
+Per-type syntax references live in [`skills/mermaid-skill/reference/`](skills/mermaid-skill/reference/) and full feature matrix in [docs/features.md](docs/features.md).
+
+## 🔄 How it works
+
+<p align="center">
+  <img src="assets/workflow.png" width="320" alt="Validation-first workflow">
+</p>
+
+Behind the scenes: **check deps (`mmdc` or Kroki) → pick diagram type → write `.mmd` → validate syntax (fix & re-validate on error) → export PNG/SVG/PDF → vision self-check the render and auto-fix readability/layout defects (≤2 rounds) → review loop on your feedback (≤5 rounds) → report output paths**. Walkthrough in [docs/workflow.md](docs/workflow.md).
+
+## 🎯 When to use (and when not to)
+
+**Good fit:**
+
+- Diagrams-as-code — define in text, get automatic layout, version-control friendly, embeds straight into Markdown / README / docs
+- Quick flowcharts, sequence, class, state, ER, gantt, and mindmaps from a text description
+- When the source should live next to your code and re-render automatically
+
+**Reach for a sibling skill instead when you need:**
+
+- **Pixel-precise placement, custom layout, branded icons, or heavy styling** → [drawio-skill](https://github.com/Agents365-ai/drawio-skill)
+- **A hand-drawn / sketchy aesthetic** → [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) or [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+- **A freeform whiteboard or freehand drawing** → [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+- **Strict, conventional UML notation** → [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill)
+
+## 🔗 Related Skills
+
+Part of the [Agents365-ai diagram-skill family](https://github.com/Agents365-ai) — pick the right tool for the job:
+
+| Skill | Style | Best for |
+| --- | --- | --- |
+| [drawio-skill](https://github.com/Agents365-ai/drawio-skill) | XML, manual layout control | Polished architecture diagrams, ML model figures |
+| [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) | Hand-drawn / sketchy | Whiteboard mockups, informal diagrams |
+| [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill) | UML-focused | Class / sequence diagrams in CI pipelines |
+| [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill) | Whiteboard collaboration | Casual sketches, FigJam-style boards |
+
+## ❤️ Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="Give a Reward">
+      <br>
+      <b>Give a Reward</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 Author
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/plugins/mermaid/README_CN.md
+++ b/plugins/mermaid/README_CN.md
@@ -1,0 +1,205 @@
+# mermaid-skill —— 从代码到图片,一步到位
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/mermaid-skill?style=flat&logo=github)](https://github.com/Agents365-ai/mermaid-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/mermaid-skill?style=flat&logo=github)](https://github.com/Agents365-ai/mermaid-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/mermaid-skill?logo=github)](https://github.com/Agents365-ai/mermaid-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/mermaid-skill?logo=github)](https://github.com/Agents365-ai/mermaid-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-mermaid-skill-skills-mermaid-skill-skill-md)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-兼容-2ea44f)](https://agentskills.io)
+[English](README.md) · **中文** · [📖 在线文档](https://agents365-ai.github.io/mermaid-skill/zh.html)
+
+一个把自然语言转成 `.mmd` 源码、导出前自动校验语法,再通过 `mmdc` CLI 或 Kroki HTTP API 渲染为 PNG / SVG / PDF 的技能。兼容任何遵循 [Agent Skills](https://agentskills.io) 规范的 agent。
+
+<p align="center">
+  <img src="assets/example.png" width="900" alt="微服务架构 —— 来自一条自然语言提示词">
+</p>
+
+## ✨ 核心亮点
+
+- **17+ 种图表类型** —— 流程图、时序图、类图、ER、状态图、甘特、饼图、Git 图、C4 上下文、思维导图等,全部自动布局(无需 x/y 坐标)
+- **校验优先的工作流** —— 每个 `.mmd` 都先解析再导出,坏图永远不会变成 PNG(校验默认走 Kroki,不需要浏览器;Chrome 只在本地导出时才需要)
+- **mermaid.live 交接链接** —— 评审循环结束后一键生成链接,在浏览器里继续微调当前图
+- **视觉自检 + 评审循环** —— 读取导出的 PNG,捕捉自动布局也防不住的可读性/排版缺陷(标签被截断、过于拥挤、方向不当),自动修复(≤2 轮),再根据你的反馈迭代(≤5 轮)
+- **两套后端,一个技能** —— 本地 `mmdc` 质量最佳,Kroki HTTP API 作为零安装备选(只要 `curl`)
+- **文本源码 = 友好版本管理** —— `.mmd` 是纯文本,在 PR 里 diff 清晰,可直接嵌入 GitHub / GitLab README
+- **主动触发** —— 讨论架构、API 流程、状态机时自动激活(中英文关键词都支持)
+- **多智能体、零配置** —— 单个 SKILL.md,无 MCP,无后台 daemon(可选的 `npx` 安装器需要 Node,技能本身不需要)
+- **批量出图模式** —— 扫描整个仓库,生成一组图(ER + 时序 + 状态 + 流程)外加一个自包含 HTML 总览页
+- **CI/Docker 就绪** —— 内置 `puppeteer-config.json`,容器内 `--no-sandbox` 导出不再报错
+
+## 🖼️ 示例
+
+> [!TIP]
+> **页首那张图就是用下面这条提示词生成的:**
+
+```
+画一个微服务电商架构图,包含 Mobile/Web 客户端、API 网关、
+User/Order/Product/Payment 服务,以及 User DB / Order DB /
+Product DB / Redis Cache
+```
+
+### 更多图表类型
+
+Mermaid 自动布局 17+ 种类型 —— 下面每张都由一句提示词生成,并走了 校验 → 导出 → 自检 流程:
+
+<table>
+  <tr>
+    <td align="center"><img src="assets/example-sequence.png" width="260" alt="OAuth 登录时序图"><br><sub><b>时序图</b> · 认证流程</sub></td>
+    <td align="center"><img src="assets/example-class.png" width="140" alt="博客领域类图"><br><sub><b>类图</b> · 领域模型</sub></td>
+    <td align="center"><img src="assets/example-state.png" width="150" alt="订单生命周期状态机"><br><sub><b>状态图</b> · 订单生命周期</sub></td>
+  </tr>
+  <tr>
+    <td align="center"><img src="assets/example-er.png" width="240" alt="电商 ER 图"><br><sub><b>ER 图</b> · 电商 schema</sub></td>
+    <td align="center"><img src="assets/example-gantt.png" width="300" alt="产品发布甘特图"><br><sub><b>甘特图</b> · 发布计划</sub></td>
+    <td align="center"><img src="assets/example-gitgraph.png" width="300" alt="Git 分支策略图"><br><sub><b>Git 图</b> · 分支策略</sub></td>
+  </tr>
+</table>
+
+完整能力矩阵见 [docs/features_CN.md](docs/features_CN.md)。页首、工作流与画廊插图的源 `.mmd` 与导出 PNG 都放在 [`assets/`](assets/) 目录(`example-{sequence,class,state,er,gantt,gitgraph}.mmd`)。
+
+## 🚀 安装
+
+### 1. 选择导出后端
+
+| 选项 | 命令 | 适用场景 |
+| --- | --- | --- |
+| **A —— 本地 `mmdc`** | `npm install -g @mermaid-js/mermaid-cli && mmdc --version` | 质量最佳、可控主题、离线使用 |
+| **B —— Kroki API** | `curl --version` | 无需安装、无需 Node、CI/CD 流水线 |
+
+技能会先尝试 `mmdc`,失败时自动回退到 Kroki。
+
+### 2. 安装技能
+
+```bash
+# 任意 Agent(Claude Code、Cursor、Copilot 等)
+npx skills add Agents365-ai/365-skills -g
+```
+
+```text
+# Claude Code 插件市场
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install mermaid
+```
+
+```bash
+# 手动安装
+git clone https://github.com/Agents365-ai/mermaid-skill.git \
+  ~/.claude/skills/mermaid-skill
+```
+
+同时索引于 [SkillsMP](https://skillsmp.com/skills/agents365-ai-mermaid-skill-skills-mermaid-skill-skill-md)。
+
+**更新:** `/plugin update mermaid`(Claude Code)、`skills update mermaid-skill`(SkillsMP),或 `git pull`(手动安装)。
+
+## ⚡ 快速开始
+
+装好之后直接描述你想要的图表,比如一个 JWT 认证时序图:
+
+```
+画一个 JWT 登录的时序图:Client 把账号密码发给 API Gateway,
+Gateway 调 Auth Service,Auth Service 查 User DB、校验密码哈希,
+然后把签名后的 JWT 沿路径返回给 Client。同时画出密码错误的失败分支。
+```
+
+技能会自动选图表类型、写 `.mmd` 源码、用 `mmdc`(或 Kroki)校验、导出你想要的格式,并报告输出路径。
+
+## 🧩 支持的图表类型
+
+| 类型 | 关键词 | 适用场景 |
+| --- | --- | --- |
+| 流程图 | `flowchart TD/LR` | 业务流程、流水线、决策树 |
+| 时序图 | `sequenceDiagram` | API 调用、认证流程、消息传递 |
+| 类图 | `classDiagram` | OOP 模型、领域实体、继承关系 |
+| ER 图 | `erDiagram` | 数据库模式、表关系 |
+| 状态图 | `stateDiagram-v2` | 状态机、生命周期 |
+| 甘特图 | `gantt` | 项目时间线、迭代规划 |
+| 饼图 | `pie` | 占比、分布 |
+| Git 图 | `gitGraph` | 分支策略、GitFlow |
+| C4 上下文 | `C4Context` | 高层架构 |
+| 架构图 | `architecture-beta` | 云 / CI-CD 服务布局 |
+| 思维导图 | `mindmap` | 主题拆解、头脑风暴 |
+| 用户旅程 | `journey` | 用户路径 |
+| 用例图 | `usecase-beta` | 参与者与系统交互 (UML) |
+| Cynefin | `cynefin-beta` | 复杂度域 / 决策框架 |
+| 事件建模 | `eventmodeling` | 事件驱动系统时间线 |
+| 树视图 | `treeView-beta` | 文件 / 目录层级 |
+| Wardley 地图 | `wardley-beta` | 商业战略 / 价值链 |
+
+各类型语法参考见 [`skills/mermaid-skill/reference/`](skills/mermaid-skill/reference/),完整能力矩阵见 [docs/features_CN.md](docs/features_CN.md)。
+
+## 🔄 工作流程
+
+<p align="center">
+  <img src="assets/workflow_cn.png" width="320" alt="校验优先的工作流">
+</p>
+
+幕后流程:**检查依赖(`mmdc` 或 Kroki)→ 选图表类型 → 写 `.mmd` → 校验语法(出错则修复并重新校验)→ 导出 PNG/SVG/PDF → 视觉自检渲染图并自动修复可读性/排版缺陷(≤2 轮)→ 根据你的反馈评审循环(≤5 轮)→ 报告输出路径**。详见 [docs/workflow_CN.md](docs/workflow_CN.md)。
+
+## 🎯 何时用(以及何时别用)
+
+**适合:**
+
+- 以代码画图 —— 文本定义、自动布局、对版本控制友好,可直接嵌入 Markdown / README / 文档
+- 从文字描述快速生成流程图、时序图、类图、状态图、ER 图、甘特图、思维导图
+- 希望图的源码就放在代码旁边、自动重新渲染的场景
+
+**这些情况请改用同系列的其它 skill:**
+
+- **像素级定位、自定义布局、品牌图标、复杂样式** → [drawio-skill](https://github.com/Agents365-ai/drawio-skill)
+- **手绘 / 潦草观感** → [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) 或 [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+- **无限画布 / 自由手绘** → [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+- **严格、规范的 UML 记法** → [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill)
+
+## 🔗 相关 Skill
+
+[Agents365-ai 图表 skill 家族](https://github.com/Agents365-ai) 一员 —— 按场景挑工具:
+
+| Skill | 风格 | 适用场景 |
+| --- | --- | --- |
+| [drawio-skill](https://github.com/Agents365-ai/drawio-skill) | XML、可手动控制布局 | 精修架构图、ML 模型图 |
+| [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) | 手绘 / 草图 | 白板原型、非正式图 |
+| [plantuml-skill](https://github.com/Agents365-ai/plantuml-skill) | UML 专精 | CI 流水线里的类图 / 序列图 |
+| [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill) | 白板协作 | 随手画、FigJam 风格 |
+
+## ❤️ 支持作者
+
+如果这个 skill 对你有帮助,欢迎支持作者:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="打赏">
+      <br>
+      <b>打赏</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 作者
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 许可证
+
+[MIT](LICENSE)

--- a/plugins/plantuml/LICENSE
+++ b/plugins/plantuml/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/plantuml/README.md
+++ b/plugins/plantuml/README.md
@@ -1,0 +1,210 @@
+# plantuml-skill — From Text to Professional UML Diagrams
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/plantuml-skill?style=flat&logo=github)](https://github.com/Agents365-ai/plantuml-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/plantuml-skill?style=flat&logo=github)](https://github.com/Agents365-ai/plantuml-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/plantuml-skill?logo=github)](https://github.com/Agents365-ai/plantuml-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/plantuml-skill?logo=github)](https://github.com/Agents365-ai/plantuml-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-plantuml-skill-skills-plantuml-skill-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/plantuml-pro-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+**English** · [中文](README_CN.md) · [📖 Online Docs](https://agents365-ai.github.io/plantuml-skill/)
+
+A skill that turns natural-language descriptions into `.puml` PlantUML source and exports diagrams to PNG / SVG via the [Kroki](https://kroki.io) rendering API — no Java, no Graphviz, no local install (just `curl`). Local Kroki Docker and `plantuml.jar` fallbacks are available for offline / air-gapped use. Works with **Claude Code, Cursor, Copilot, OpenClaw, Codex, Hermes**, and any agent compatible with the [Agent Skills](https://agentskills.io) format.
+
+<p align="center">
+  <img src="assets/example.png" width="900" alt="Microservices architecture rendered from a natural-language prompt via PlantUML + Kroki">
+</p>
+
+## ✨ Highlights
+
+- **10+ diagram types** — sequence, component, class, ER, activity, use case, state, C4, mind map, gantt — each with idiomatic syntax templates and shape vocabulary
+- **Zero-install default** — public Kroki API needs only `curl`; no Node, no Java, no Graphviz
+- **3 rendering backends** — public Kroki, local Kroki via Docker (offline), or `plantuml.jar` + Java + Graphviz (air-gapped) — picks by sensitivity, never silently downgrades, and reports whether your source left the machine
+- **5 built-in themes** — `plain`, `cerulean`, `blueprint`, `aws-orange`, `vibrant` — plus full `skinparam` overrides
+- **C4 that actually works** — uses Kroki's `c4plantuml` endpoint to sidestep the public PlantUML server's `!include` 404 trap
+- **Common Mistakes guide** — 9-row curated table covering arrow direction, layout overflow, label escaping, participant ordering, and the C4 include pitfall
+- **Vision self-check + review loop** — beyond the syntax/render self-correct loop, reads the exported PNG to catch readability defects auto-layout can't prevent (clipped labels, component overlap, wrong orientation), auto-fixes (≤2 rounds), then iterates with you (≤5 rounds)
+- **Beyond text → diagram** — also generates diagrams from existing **source code** (class/sequence/component/ER), and **renders PlantUML embedded in Markdown** to images, rewriting the doc with image links (Confluence / Notion-ready)
+
+## 🖼️ Examples
+
+> [!TIP]
+> **The hero image above was generated from this single prompt:**
+
+```
+Create a microservices e-commerce architecture with Mobile/Web/Admin clients,
+API Gateway, User/Order/Product/Payment services, Kafka event bus,
+Notification service, and User DB / Order DB / Product DB / Redis Cache /
+Stripe API
+```
+
+Source `.puml` and rendered PNG live in [`assets/`](assets/) — the skill produced both in one shot.
+
+### More examples — different types & themes
+
+Six diagram types, each in a different built-in theme — all rendered via Kroki. Sources + PNGs in [`assets/examples/`](assets/examples/).
+
+<table>
+  <tr>
+    <td align="center"><img src="assets/examples/sequence-oauth.png" width="240" alt="OAuth 2.0 authorization code flow sequence diagram"><br><sub><b>Sequence</b> · <code>plain</code></sub></td>
+    <td align="center"><img src="assets/examples/class-blog.png" width="240" alt="Blog domain class diagram"><br><sub><b>Class</b> · <code>cerulean</code></sub></td>
+    <td align="center"><img src="assets/examples/er-ecommerce.png" width="240" alt="E-commerce database ER diagram"><br><sub><b>ER</b> · <code>aws-orange</code></sub></td>
+  </tr>
+  <tr>
+    <td align="center"><img src="assets/examples/state-order.png" width="240" alt="Order lifecycle state machine"><br><sub><b>State</b> · <code>vibrant</code></sub></td>
+    <td align="center"><img src="assets/examples/activity-cicd.png" width="240" alt="CI/CD pipeline activity diagram"><br><sub><b>Activity</b> · <code>blueprint</code></sub></td>
+    <td align="center"><img src="assets/examples/c4-banking.png" width="240" alt="Internet banking C4 system context diagram"><br><sub><b>C4 Context</b> · <code>&lt;C4/…&gt;</code></sub></td>
+  </tr>
+</table>
+
+## 🚀 Installation
+
+### 1. Pick a rendering backend
+
+| Option | Install | When to use |
+| --- | --- | --- |
+| **Kroki API** (default) | `curl` (pre-installed everywhere) | Online — zero setup |
+| **Local Kroki** | `docker run -d -p 8000:8000 yuzutech/kroki` | Offline / privacy / heavy workloads |
+| **`plantuml.jar`** | `brew install graphviz openjdk` + [download jar](https://plantuml.com/download) | Fully air-gapped |
+
+Full recipes in [docs/setup.md](docs/setup.md).
+
+### 2. Install the skill
+
+```bash
+# Any agent (Claude Code, Cursor, Copilot, ...)
+npx skills add Agents365-ai/365-skills -g
+```
+
+```text
+# Claude Code plugin marketplace
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install plantuml
+```
+
+```bash
+# Manual install
+git clone https://github.com/Agents365-ai/plantuml-skill.git \
+  ~/.claude/skills/plantuml-skill
+```
+
+Common paths: `~/.claude/skills/` (Claude Code), `~/.config/opencode/skills/` (Opencode), `~/.openclaw/skills/` (OpenClaw), `~/.agents/skills/` (Codex). Also indexed on [SkillsMP](https://skillsmp.com/skills/agents365-ai-plantuml-skill-skills-plantuml-skill-skill-md) and [ClawHub](https://clawhub.ai/agents365-ai/plantuml-pro-skill).
+
+**Updating:** `/plugin update plantuml` (Claude Code), `skills update plantuml-skill` (SkillsMP), `clawhub update plantuml-pro-skill` (OpenClaw), or `git pull` for manual installs.
+
+## ⚡ Quick Start
+
+After installation, just describe what you want:
+
+```
+Create a sequence diagram showing the OAuth 2.0 authorization code flow with
+Client, Authorization Server, Resource Server, and User. Include the redirect,
+token exchange, and resource access steps with proper activation boxes.
+```
+
+The skill picks the right diagram type, generates the `.puml` source, and exports to PNG/SVG via Kroki.
+
+## 🧩 Supported Diagram Types
+
+| Category | Examples | Notable features |
+| --- | --- | --- |
+| Sequence | API calls, OAuth flows, protocol traces | Lifelines, activation boxes, async arrows |
+| Component / Architecture | services, modules, queues, databases, clouds | `package`/`rectangle` grouping, shape vocabulary |
+| Class | OOP models, data structures | Inheritance, composition, aggregation, multiplicities (`"1" --> "*"`) |
+| ER / Entity | database schemas | `<<PK>>` / `<<FK>>` notation, crow's-foot relationships |
+| Activity / Flowchart | workflows, business processes | `if/then/else/endif` decision branches |
+| Use Case | system requirements, user stories | Actors, system boundaries |
+| State | state machines, lifecycle flows | `[*] -->` start/end markers |
+| C4 | Context, Container, Component | Via Kroki's `c4plantuml` endpoint (no broken includes) |
+| Other | mind maps, gantt | `@startmindmap`, `@startgantt` |
+
+## 🔄 How it works
+
+Behind the scenes: **check `curl`** → **pick diagram type** → **generate `.puml` source** with `@startuml`/`@enduml` markers → **POST to Kroki** (`https://kroki.io/plantuml/png` or `…/svg`) → **validate & self-correct the render (fix syntax, ≤3 rounds)** → **vision self-check readability and auto-fix (≤2 rounds)** → **review loop on your feedback (≤5 rounds)** → **save output + report paths**. Swap the endpoint for `http://localhost:8000` to use a local Kroki container, or run `java -jar plantuml.jar` for air-gapped renders.
+
+## 🆚 Comparison
+
+### vs Native Agent (no skill)
+
+| Feature | Native agent | plantuml-skill |
+| --- | --- | --- |
+| Generate PlantUML source | ✅ (LLMs know the syntax) | ✅ |
+| Export to PNG/SVG | ❌ outputs text only | ✅ one `curl` POST to Kroki |
+| Self-correct on render error | ❌ ships broken output | ✅ checks HTTP/bytes, fixes syntax, retries (≤3 rounds) |
+| Vision self-check + review loop | ❌ never looks at the render | ✅ reads the PNG, auto-fixes readability (≤2), then iterates on feedback (≤5) |
+| Renderer choice | none | ✅ public Kroki / local Kroki / `plantuml.jar` |
+| Diagram-type catalog | implicit | ✅ 10+ types with shape & arrow vocabulary |
+| Theme defaults | random per run | ✅ 5 named themes + `skinparam` overrides |
+| C4 via cloud | ❌ often broken (`!include` 404s) | ✅ Kroki `c4plantuml` endpoint |
+| Common-mistake guard rails | ❌ | ✅ 9-row curated pitfalls table |
+| Offline / air-gapped | ❌ | ✅ local Kroki Docker or local jar |
+
+Full comparison + key-advantages summary in [docs/features.md](docs/features.md).
+
+## 🎯 When to use (and when not to)
+
+**Good fit:**
+
+- Standardized UML — class, sequence, state, component, use-case, activity, deployment, C4
+- Diagrams-as-code with automatic layout; ideal for CI pipelines and docs-as-code
+- When correct, conventional UML notation matters (hollow inheritance arrows, lifelines, etc.)
+
+**Reach for a sibling skill instead when you need:**
+
+- **General, non-UML quick diagrams embedded in Markdown** → [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill)
+- **Freeform, heavily-styled, or branded diagrams with pixel control** → [drawio-skill](https://github.com/Agents365-ai/drawio-skill)
+- **A hand-drawn / sketchy look** → [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) or [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+
+## 🔗 Related Skills
+
+Part of the [Agents365-ai diagram-skill family](https://github.com/Agents365-ai) — pick the right tool for the job:
+
+| Skill | Style | Best for |
+| --- | --- | --- |
+| [drawio-skill](https://github.com/Agents365-ai/drawio-skill) | Professional / vector | Architecture, ML/DL, ER diagrams with self-check loop |
+| [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) | Hand-drawn / sketchy | Whiteboard mockups, informal diagrams |
+| [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill) | Text-based, auto-layout | README-embeddable, version-control friendly |
+| [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill) | Whiteboard collaboration | Casual sketches, FigJam-style boards |
+
+## ❤️ Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="Give a Reward">
+      <br>
+      <b>Give a Reward</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 Author
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/plugins/plantuml/README_CN.md
+++ b/plugins/plantuml/README_CN.md
@@ -1,0 +1,209 @@
+# plantuml-skill —— 从文字到专业 UML 图表
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/plantuml-skill?style=flat&logo=github)](https://github.com/Agents365-ai/plantuml-skill/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/plantuml-skill?style=flat&logo=github)](https://github.com/Agents365-ai/plantuml-skill/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/plantuml-skill?logo=github)](https://github.com/Agents365-ai/plantuml-skill/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/plantuml-skill?logo=github)](https://github.com/Agents365-ai/plantuml-skill/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-plantuml-skill-skills-plantuml-skill-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/plantuml-pro-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-兼容-2ea44f)](https://agentskills.io)
+[English](README.md) · **中文** · [📖 在线文档](https://agents365-ai.github.io/plantuml-skill/zh.html)
+
+一个把自然语言描述变成 `.puml` PlantUML 源文件,并通过 [Kroki](https://kroki.io) 渲染 API 导出为 PNG / SVG 的技能 —— 无需 Java、无需 Graphviz、无需本地安装(只要 `curl`)。离线 / 气隙场景可使用本地 Kroki Docker 或 `plantuml.jar`。支持 **Claude Code、Cursor、Copilot、OpenClaw、Codex、Hermes** 等任何兼容 [Agent Skills](https://agentskills.io) 规范的 agent。
+
+<p align="center">
+  <img src="assets/example.png" width="900" alt="微服务架构图 —— 用自然语言提示词经 PlantUML + Kroki 渲染">
+</p>
+
+## ✨ 核心亮点
+
+- **10+ 种图表类型** —— 时序图、组件图、类图、ER 图、活动图、用例图、状态图、C4、思维导图、Gantt,每种都带地道语法模板与形状词汇
+- **零安装默认值** —— 公共 Kroki API 只需要 `curl`,无需 Node、Java、Graphviz
+- **3 种渲染后端** —— 公共 Kroki、本地 Kroki Docker(离线)、`plantuml.jar` + Java + Graphviz(气隙);按内容敏感度自动选择,绝不静默降级,并会告知你源码是否离开了本机
+- **5 套内置主题** —— `plain`、`cerulean`、`blueprint`、`aws-orange`、`vibrant`,加完整的 `skinparam` 覆盖
+- **C4 真的能用** —— 通过 Kroki 的 `c4plantuml` 端点绕开公共 PlantUML 服务器的 `!include` 404 陷阱
+- **常见错误指南** —— 精选 9 行表格:箭头方向、布局溢出、标签转义、参与者顺序、C4 include 陷阱等
+- **视觉自检 + 评审循环** —— 在语法/渲染自纠循环之外,读取导出的 PNG,捕捉自动布局也防不住的可读性缺陷(标签被截断、组件重叠、方向不当),自动修复(≤2 轮),再根据你的反馈迭代(≤5 轮)
+- **不止「文字→图」** —— 还能从**现有源码**生成图(类图/时序/组件/ER),以及把 **Markdown 里内嵌的 PlantUML** 渲染成图片并回写为图片链接(适配 Confluence / Notion)
+
+## 🖼️ 示例
+
+> [!TIP]
+> **页首那张图就是用下面这条提示词生成的:**
+
+```
+画一个微服务电商架构图,包含 Mobile/Web/Admin 客户端、API Gateway、
+User/Order/Product/Payment 微服务、Kafka 事件总线、Notification 服务,
+以及 User DB / Order DB / Product DB / Redis Cache / Stripe API
+```
+
+源 `.puml` 与渲染后的 PNG 都在 [`assets/`](assets/) 里 —— 技能一次产出。
+
+### 更多示例 —— 不同类型与主题
+
+六种图类型,各用一种内置主题,全部经 Kroki 渲染。源文件与 PNG 在 [`assets/examples/`](assets/examples/)。
+
+<table>
+  <tr>
+    <td align="center"><img src="assets/examples/sequence-oauth.png" width="240" alt="OAuth 2.0 授权码流程时序图"><br><sub><b>时序图</b> · <code>plain</code></sub></td>
+    <td align="center"><img src="assets/examples/class-blog.png" width="240" alt="博客领域模型类图"><br><sub><b>类图</b> · <code>cerulean</code></sub></td>
+    <td align="center"><img src="assets/examples/er-ecommerce.png" width="240" alt="电商数据库 ER 图"><br><sub><b>ER 图</b> · <code>aws-orange</code></sub></td>
+  </tr>
+  <tr>
+    <td align="center"><img src="assets/examples/state-order.png" width="240" alt="订单生命周期状态机"><br><sub><b>状态图</b> · <code>vibrant</code></sub></td>
+    <td align="center"><img src="assets/examples/activity-cicd.png" width="240" alt="CI/CD 流水线活动图"><br><sub><b>活动图</b> · <code>blueprint</code></sub></td>
+    <td align="center"><img src="assets/examples/c4-banking.png" width="240" alt="网银系统 C4 上下文图"><br><sub><b>C4 上下文</b> · <code>&lt;C4/…&gt;</code></sub></td>
+  </tr>
+</table>
+
+## 🚀 安装
+
+### 1. 选择渲染后端
+
+| 方式 | 安装 | 适用 |
+| --- | --- | --- |
+| **Kroki API**(默认) | `curl`(全平台预装) | 在线 —— 零配置 |
+| **本地 Kroki** | `docker run -d -p 8000:8000 yuzutech/kroki` | 离线 / 隐私 / 高负载 |
+| **`plantuml.jar`** | `brew install graphviz openjdk` + [下载 jar](https://plantuml.com/download) | 完全气隙环境 |
+
+完整方案见 [docs/setup_CN.md](docs/setup_CN.md)。
+
+### 2. 安装技能
+
+```bash
+# 任意 Agent(Claude Code、Cursor、Copilot 等)
+npx skills add Agents365-ai/365-skills -g
+```
+
+```text
+# Claude Code 插件市场
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install plantuml
+```
+
+```bash
+# 手动安装
+git clone https://github.com/Agents365-ai/plantuml-skill.git \
+  ~/.claude/skills/plantuml-skill
+```
+
+常用路径:`~/.claude/skills/`(Claude Code)、`~/.config/opencode/skills/`(Opencode)、`~/.openclaw/skills/`(OpenClaw)、`~/.agents/skills/`(Codex)。同时索引于 [SkillsMP](https://skillsmp.com/skills/agents365-ai-plantuml-skill-skills-plantuml-skill-skill-md) 与 [ClawHub](https://clawhub.ai/agents365-ai/plantuml-pro-skill)。
+
+**更新:** `/plugin update plantuml`(Claude Code)、`skills update plantuml-skill`(SkillsMP)、`clawhub update plantuml-pro-skill`(OpenClaw),或 `git pull`(手动安装)。
+
+## ⚡ 快速开始
+
+装好之后直接描述你想要的图表:
+
+```
+画一个 OAuth 2.0 授权码流程的时序图,包含 Client、Authorization Server、
+Resource Server 和 User。展示跳转、token 交换、资源访问等步骤,
+带上正确的激活框。
+```
+
+Skill 会自动挑选合适的图表类型,生成 `.puml` 源文件,并通过 Kroki 导出为 PNG/SVG。
+
+## 🧩 支持的图表类型
+
+| 类别 | 示例 | 特色 |
+| --- | --- | --- |
+| 时序图 | API 调用、OAuth 流程、协议追踪 | 生命线、激活框、异步箭头 |
+| 组件 / 架构 | 服务、模块、队列、数据库、云组件 | `package`/`rectangle` 分组、形状词汇 |
+| 类图 | OOP 模型、数据结构 | 继承、组合、聚合、多重性(`"1" --> "*"`) |
+| ER / 实体 | 数据库 Schema | `<<PK>>` / `<<FK>>` 标记、鱼尾纹关系 |
+| 活动 / 流程图 | 工作流、业务流程 | `if/then/else/endif` 分支判断 |
+| 用例图 | 系统需求、用户故事 | 角色、系统边界 |
+| 状态图 | 状态机、生命周期 | `[*] -->` 起止标记 |
+| C4 | Context、Container、Component | 通过 Kroki `c4plantuml` 端点(includes 不会 404) |
+| 其他 | 思维导图、Gantt | `@startmindmap`、`@startgantt` |
+
+## 🔄 工作流程
+
+幕后流程:**检查 `curl`** → **挑选图表类型** → **生成 `.puml` 源**(`@startuml`/`@enduml`)→ **POST 到 Kroki**(`https://kroki.io/plantuml/png` 或 `…/svg`)→ **校验并自纠渲染(修语法,≤3 轮)** → **视觉自检可读性并自动修复(≤2 轮)** → **根据你的反馈评审循环(≤5 轮)** → **保存输出 + 上报路径**。把端点改成 `http://localhost:8000` 即用本地 Kroki 容器;`java -jar plantuml.jar` 则用于气隙渲染。
+
+## 🆚 对比
+
+### 对比原生智能体(无 skill)
+
+| 功能 | 原生智能体 | plantuml-skill |
+| --- | --- | --- |
+| 生成 PlantUML 源码 | ✅(LLM 懂语法) | ✅ |
+| 导出 PNG/SVG | ❌ 只能输出文本 | ✅ 一次 `curl` POST 到 Kroki |
+| 渲染出错自纠 | ❌ 直接交付坏图 | ✅ 查 HTTP/字节、修语法、重试(≤3 轮) |
+| 视觉自检 + 评审循环 | ❌ 从不看渲染结果 | ✅ 读 PNG、自动修可读性(≤2),再按反馈迭代(≤5) |
+| 渲染后端可选 | 无 | ✅ 公共 Kroki / 本地 Kroki / `plantuml.jar` |
+| 图表类型清单 | 隐式 | ✅ 10+ 种带形状与箭头词汇 |
+| 主题默认值 | 每次随机 | ✅ 5 套命名主题 + `skinparam` 覆盖 |
+| 云端 C4 | ❌ 常因 `!include` 404 失败 | ✅ 使用 Kroki `c4plantuml` 端点 |
+| 常见错误防护 | ❌ | ✅ 9 行精选错误表 |
+| 离线 / 气隙 | ❌ | ✅ 本地 Kroki Docker 或本地 jar |
+
+完整对比 + 核心优势见 [docs/features_CN.md](docs/features_CN.md)。
+
+## 🎯 何时用(以及何时别用)
+
+**适合:**
+
+- 规范的 UML —— 类图、时序图、状态图、组件图、用例图、活动图、部署图、C4
+- 以代码画图 + 自动布局;非常适合 CI 流水线与 docs-as-code
+- 看重正确、规范的 UML 记法(空心继承箭头、生命线等)
+
+**这些情况请改用同系列的其它 skill:**
+
+- **通用的、非 UML 的、嵌入 Markdown 的快速图** → [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill)
+- **自由排布、重样式、带品牌图标且要像素级控制的图** → [drawio-skill](https://github.com/Agents365-ai/drawio-skill)
+- **手绘 / 潦草观感** → [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) 或 [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill)
+
+## 🔗 相关 Skill
+
+[Agents365-ai 图表 skill 家族](https://github.com/Agents365-ai) 一员 —— 按场景挑工具:
+
+| Skill | 风格 | 适用场景 |
+| --- | --- | --- |
+| [drawio-skill](https://github.com/Agents365-ai/drawio-skill) | 专业 / 矢量 | 架构图、ML/DL、ER 图,带自检循环 |
+| [excalidraw-skill](https://github.com/Agents365-ai/excalidraw-skill) | 手绘 / 草图 | 白板原型、非正式图 |
+| [mermaid-skill](https://github.com/Agents365-ai/mermaid-skill) | 文本驱动、自动布局 | 可嵌入 README、易于版本管理 |
+| [tldraw-skill](https://github.com/Agents365-ai/tldraw-skill) | 白板协作 | 随手画、FigJam 风格 |
+
+## ❤️ 支持作者
+
+如果这个 skill 对你有帮助,欢迎支持作者:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="打赏">
+      <br>
+      <b>打赏</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 作者
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 许可证
+
+[MIT](LICENSE)


### PR DESCRIPTION
Restore README.md / README_CN.md / LICENSE at the plugin root for asta, excalidraw, mermaid, and plantuml, pulled from each source repo (Agents365-ai/*-skill) so the distribution repo stays browsable. Do not merge; awaiting review.