### PR TITLE
fix(pi-dev-rules): pin TLS context and narrow fetch exceptions (0.2.1)

### DIFF
--- a/plugins/pi-dev-rules/skills/pi-dev-rules/SKILL.md
+++ b/plugins/pi-dev-rules/skills/pi-dev-rules/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: pi-dev-rules
-version: 0.2.0
+version: 0.2.1
 description: Authoritative reference for Pi (`@earendil-works/pi-coding-agent`): install, configure, run, and extend. Use when the user asks about Pi CLI/flags/commands, providers/models/auth, settings/compaction/sessions, security/trust, extensions, skills, prompt templates, themes, packages, custom providers, TUI components, the SDK, RPC mode, or JSON streaming. Also use for Pi's design philosophy and opinionated choices (why minimal, 4 tools, YOLO, no MCP/plan mode/to-dos/sub-agents) and the creator Mario Zechner's coding-agent blog post.
 license: MIT
-metadata: {"source":"https://pi.dev/docs/latest","docVersion":"latest","fetched":"2026-09-04"}
+metadata: {"source":"https://pi.dev/docs/latest","docVersion":"latest","fetched":"2026-09-04","version":"0.2.1"}
 ---
 
 # Pi Dev Rules

--- a/plugins/pi-dev-rules/skills/pi-dev-rules/scripts/fetch-changelog.py
+++ b/plugins/pi-dev-rules/skills/pi-dev-rules/scripts/fetch-changelog.py
@@ -7,7 +7,10 @@ Usage: python3 scripts/fetch-changelog.py [output.md]
 import html
 import os
 import re
+import ssl
 import sys
+import urllib.error
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from email.utils import parsedate_to_datetime
@@ -58,11 +61,12 @@ def parse_rss():
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
         },
     )
+    ctx = ssl.create_default_context()
     try:
-        with urllib.request.urlopen(req, timeout=30) as r:
+        with urllib.request.urlopen(req, timeout=30, context=ctx) as r:
             data = r.read()
-    except Exception as e:
-        raise SystemExit(f"Failed to fetch RSS: {e}")
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise SystemExit(f"Failed to fetch RSS: {e}") from e
 
     root = ET.fromstring(data)
     ns = {"content": "http://purl.org/rss/1.0/modules/content/"}


### PR DESCRIPTION
fetch-changelog.py: pass an explicit ssl.create_default_context() to urlopen (Semgrep B310/urllib-ssl-injection) and catch narrow network exceptions instead of bare Exception. Bump skill + marketplace version to 0.2.1. Verified live: fetches 20 RSS entries from pi.dev. Do not merge; awaiting review.