### PR TITLE
Add README and LICENSE files to journal-meta and journal-if plugins

### DIFF
--- a/plugins/journal-if/LICENSE
+++ b/plugins/journal-if/LICENSE
@@ -1,0 +1,28 @@
+Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+
+Copyright (c) 2026 Agents365-ai
+
+This work is licensed under the Creative Commons Attribution-NonCommercial 4.0
+International License. To view a copy of this license, visit:
+http://creativecommons.org/licenses/by-nc/4.0/ or send a letter to
+Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+You are free to:
+  - Share — copy and redistribute the material in any medium or format
+  - Adapt — remix, transform, and build upon the material
+
+Under the following terms:
+  - Attribution — You must give appropriate credit, provide a link to the
+    license, and indicate if changes were made. You may do so in any
+    reasonable manner, but not in any way that suggests the licensor
+    endorses you or your use.
+  - NonCommercial — You may not use the material for commercial purposes.
+
+Notices:
+  - You do not have to comply with the license for elements of the material
+    in the public domain or where your use is permitted by an applicable
+    exception or limitation.
+  - No warranties are given. The license may not give you all of the
+    permissions necessary for your intended use. For example, other rights
+    such as publicity, privacy, or moral rights may limit how you use
+    the material.

--- a/plugins/journal-if/README.md
+++ b/plugins/journal-if/README.md
@@ -1,0 +1,190 @@
+# Journal IF — Journal Impact Factor Lookup Skill
+
+[![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/journal-if?style=flat&logo=github)](https://github.com/Agents365-ai/journal-if/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/journal-if?style=flat&logo=github)](https://github.com/Agents365-ai/journal-if/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/journal-if?logo=github)](https://github.com/Agents365-ai/journal-if/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/journal-if?logo=github)](https://github.com/Agents365-ai/journal-if/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
+[中文](README_CN.md)
+
+A Claude Code skill for looking up journal impact factors (JCR IF). Bundled with ~200 top journals and backed by OpenAlex API fallback for any journal worldwide.
+
+<img src="https://raw.githubusercontent.com/Agents365-ai/journal-if/main/docs/workflow.drawio.png" width="600" alt="Workflow">
+
+## Features
+
+| Feature | Native Claude Code | Journal IF |
+| --------- | ------------------- | ------------ |
+| Impact factor lookup | Hallucination / stale data | Curated CSV + real-time API, accurate |
+| Batch processing | Not supported | One journal per line, partial-success envelope |
+| Fuzzy search | Not supported | Substring matching, paginated |
+| Offline lookup | Not supported | Bundled CSV works with `--offline` flag |
+| Agent-native output | — | Stable JSON envelope, distinct exit codes, retryable errors |
+
+## Data Sources
+
+1. **Bundled CSV** — ~200 top journals across life sciences, medicine, chemistry, physics, and engineering. Curated from JCR 2023 data, shipped with the skill. Instant, always available.
+
+2. **OpenAlex API** — Free, open API that computes an approximate 2-year impact factor from citation counts. Covers virtually all academic journals. The number differs from the official JCR IF — adequate for ranking and comparison; cite as approximate in formal contexts.
+
+## Installation
+
+The skill bundle lives at `skills/journal-if/` (containing `SKILL.md` and
+`journal_if.py`). The recommended path is the plugin marketplace — it handles
+updates for you:
+
+```bash
+# Claude Code plugin marketplace (recommended)
+/plugin marketplace add Agents365-ai/365-skills
+/plugin install journal-if
+
+# Any agent (Claude Code, Cursor, Copilot, …)
+npx skills add Agents365-ai/365-skills -g
+```
+
+Also published on [ClawHub](https://clawhub.ai/) and
+[SkillsMP](https://skillsmp.com) — each handles updates through its own
+marketplace.
+
+Or install the skill bundle manually into any `SKILL.md`-aware platform:
+
+| Platform | Install |
+| --- | --- |
+| **Claude Code** (global) | `git clone https://github.com/Agents365-ai/journal-if.git /tmp/ji && cp -r /tmp/ji/skills/journal-if ~/.claude/skills/ && rm -rf /tmp/ji` |
+| **Claude Code** (project) | `git clone https://github.com/Agents365-ai/journal-if.git /tmp/ji && cp -r /tmp/ji/skills/journal-if .claude/skills/ && rm -rf /tmp/ji` |
+| **OpenClaw** (global) | replace `~/.claude/skills/` with `~/.openclaw/skills/` in the recipe above |
+
+Or just clone the repo and run the CLI directly — it is pure Python 3.9+
+standard library with no third-party dependencies, and works on macOS, Linux,
+and Windows:
+
+```bash
+git clone https://github.com/Agents365-ai/journal-if.git
+cd journal-if/skills/journal-if
+python3 journal_if.py lookup "Nature Medicine"
+python3 journal_if.py schema              # full machine-readable CLI contract
+```
+
+## Usage
+
+### Natural Language
+
+Ask Claude directly:
+
+- "What's the impact factor of Nature Medicine?"
+- "Compare the IF of Cell and Science"
+- "Which immunology journals have IF > 20?"
+- "Look up IF for this list of journals"
+
+### Command Line
+
+```bash
+# Single journal lookup
+python3 journal_if.py lookup "Nature Medicine"
+
+# Fuzzy search (paginated)
+python3 journal_if.py search "immunology" --limit 10 --offset 0
+
+# Batch lookup (one journal per line)
+python3 journal_if.py batch journals.txt
+
+# Cache-only mode (no network)
+python3 journal_if.py --offline lookup "Cell"
+
+# Cache management
+python3 journal_if.py cache status                # inspect local cache
+python3 journal_if.py cache update                # refresh upstream CSV
+
+# Machine-readable CLI contract (for AI agents and automation)
+python3 journal_if.py schema
+python3 journal_if.py schema lookup
+```
+
+### Agent-native output contract
+
+Stdout is a stable JSON envelope when not attached to a terminal (piped or
+captured by an agent runtime), and a human table/indent view when run on a TTY.
+Every response carries the same shape:
+
+- Success: `{"ok": true, "data": ..., "meta": {"schema_version", "cli_version", "latency_ms"}}`
+- Partial (batch): `{"ok": "partial", "data": {"succeeded": [...], "failed": [...]}}`
+- Error: `{"ok": false, "error": {"code", "message", "retryable", ...}}`
+
+The `error.code` field is stable. Notable codes:
+
+| Code | Retryable | Exit | Meaning |
+| ------ | ----------- | ------ | --------- |
+| `not_found` | no | 3 | Lookup completed but no source matched |
+| `upstream_unavailable` | **yes** | 1 | OpenAlex API failed transiently; retry later or use `--offline` |
+| `file_not_found` / `validation_error` | no | 2 | Bad input |
+| `runtime_error` | yes | 1 | Unexpected internal failure |
+
+Branch on `error.code` + `error.retryable` rather than exit code alone — exit
+`1` covers both transient and runtime errors. Force a format with
+`--format json|table|human` (or the back-compat `--json`); flags may appear
+before or after the subcommand.
+
+### Understanding Impact Factor
+
+| IF Range | Typical Tier | Example |
+| ---------- | ------------- | --------- |
+| > 30 | Elite (top 0.1%) | Nature (64.8), Science (56.9), Cell (64.5) |
+| 20–30 | Exceptional (top 1%) | Cancer Cell (50.3), Immunity (32.4) |
+| 10–20 | Excellent (top 5%) | Nature Communications (16.6), Sci Adv (13.6) |
+| 5–10 | Strong (top 15%) | eLife (7.7), Cell Reports (8.8) |
+| 2–5 | Solid | PLOS ONE (3.7), Sci Rep (4.6) |
+| < 2 | Niche / new | Many field-specific and new journals |
+
+**Caveat:** IF varies dramatically by field — always compare within the same
+discipline. OpenAlex approximate IF differs from official JCR IF; use for
+ranking, not formal citation.
+
+## Requirements
+
+- Python 3.9+ (no third-party packages required)
+
+## ❤️ Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="Give a Reward">
+      <br>
+      <b>Give a Reward</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 Author
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+CC BY-NC 4.0 — Free for non-commercial use. Commercial use requires permission.

--- a/plugins/journal-if/README_CN.md
+++ b/plugins/journal-if/README_CN.md
@@ -1,0 +1,184 @@
+# Journal IF — 期刊影响因子查询技能
+
+[![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/journal-if?style=flat&logo=github)](https://github.com/Agents365-ai/journal-if/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/journal-if?style=flat&logo=github)](https://github.com/Agents365-ai/journal-if/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/journal-if?logo=github)](https://github.com/Agents365-ai/journal-if/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/journal-if?logo=github)](https://github.com/Agents365-ai/journal-if/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
+[English](README.md)
+
+一个用于查询期刊影响因子（JCR IF）的 Claude Code 技能。内置 ~200 本顶级期刊数据，并通过 OpenAlex API 回退覆盖全球任意期刊。
+
+<img src="https://raw.githubusercontent.com/Agents365-ai/journal-if/main/docs/workflow_CN.drawio.png" width="600" alt="工作流程">
+
+## 功能特性
+
+| 功能 | 原生 Claude Code | Journal IF |
+| ------ | ----------------- | ------------ |
+| 影响因子查询 | 可能产生幻觉 / 数据过时 | 精选 CSV + 实时 API，结果准确 |
+| 批量处理 | 不支持 | 每行一个期刊名，部分成功信封 |
+| 模糊搜索 | 不支持 | 子串匹配，支持分页 |
+| 离线查询 | 不支持 | `--offline` 参数使用内置 CSV |
+| Agent-native 输出 | — | 稳定 JSON 信封，独立退出码，可重试错误 |
+
+## 数据来源
+
+1. **内置 CSV** — ~200 本顶级期刊，涵盖生命科学、医学、化学、物理和工程领域。精选自 JCR 2023 数据，随技能附带。即时查询，始终可用。
+
+2. **OpenAlex API** — 免费开放的 API，基于引用计数计算近似的 2 年影响因子。覆盖几乎所有学术期刊。该数值与官方 JCR IF 有所不同 —— 适合排名和比较，在正式场合请注明为近似值。
+
+## 安装
+
+技能本体位于 `skills/journal-if/`（包含 `SKILL.md` 和 `journal_if.py`）。
+推荐通过插件市场安装，会自动处理升级：
+
+```bash
+# Claude Code 插件市场（推荐）
+/plugin marketplace add Agents365-ai/365-skills
+/plugin install journal-if
+
+# 任意 Agent（Claude Code、Cursor、Copilot 等）
+npx skills add Agents365-ai/365-skills -g
+```
+
+也发布在 [ClawHub](https://clawhub.ai/) 与 [SkillsMP](https://skillsmp.com)
+上 —— 各自的市场都会处理升级。
+
+也可以手动把 skill bundle 安装到任意支持 `SKILL.md` 的平台：
+
+| 平台 | 安装命令 |
+| --- | --- |
+| **Claude Code**（全局） | `git clone https://github.com/Agents365-ai/journal-if.git /tmp/ji && cp -r /tmp/ji/skills/journal-if ~/.claude/skills/ && rm -rf /tmp/ji` |
+| **Claude Code**（项目） | `git clone https://github.com/Agents365-ai/journal-if.git /tmp/ji && cp -r /tmp/ji/skills/journal-if .claude/skills/ && rm -rf /tmp/ji` |
+| **OpenClaw**（全局） | 把上面命令里的 `~/.claude/skills/` 换成 `~/.openclaw/skills/` |
+
+或者直接克隆仓库运行 CLI —— 纯 Python 3.9+ 标准库实现，
+无任何第三方依赖，在 macOS、Linux、Windows 上均可运行：
+
+```bash
+git clone https://github.com/Agents365-ai/journal-if.git
+cd journal-if/skills/journal-if
+python3 journal_if.py lookup "Nature Medicine"
+python3 journal_if.py schema              # 完整机器可读的 CLI 契约
+```
+
+## 使用方法
+
+### 自然语言
+
+直接向 Claude 提问：
+
+- "Nature Medicine 的影响因子是多少？"
+- "比较一下 Cell 和 Science 的影响因子"
+- "免疫学领域有哪些 IF > 20 的期刊？"
+- "帮我查一下这个期刊列表的影响因子"
+
+### 命令行
+
+```bash
+# 单本期刊查询
+python3 journal_if.py lookup "Nature Medicine"
+
+# 模糊搜索（支持分页）
+python3 journal_if.py search "免疫" --limit 10 --offset 0
+
+# 批量查询（每行一个期刊名）
+python3 journal_if.py batch journals.txt
+
+# 纯离线模式（不访问网络）
+python3 journal_if.py --offline lookup "Cell"
+
+# 缓存管理
+python3 journal_if.py cache status                # 查看本地缓存状态
+python3 journal_if.py cache update                # 刷新上游 CSV
+
+# 机器可读的命令契约（供 AI 智能体或自动化工具使用）
+python3 journal_if.py schema
+python3 journal_if.py schema lookup
+```
+
+### Agent-native 输出契约
+
+当标准输出不是终端（例如被管道捕获、被智能体运行时读取）时，`stdout` 默认输出
+稳定的 JSON 信封；在终端下则输出人类友好的表格或缩进视图。所有响应共用同一信封结构：
+
+- 成功: `{"ok": true, "data": ..., "meta": {"schema_version", "cli_version", "latency_ms"}}`
+- 部分成功（batch）: `{"ok": "partial", "data": {"succeeded": [...], "failed": [...]}}`
+- 错误: `{"ok": false, "error": {"code", "message", "retryable", ...}}`
+
+`error.code` 字段稳定。主要的错误码：
+
+| 错误码 | 可重试 | 退出码 | 含义 |
+| -------- | -------- | -------- | ------ |
+| `not_found` | 否 | 3 | 查询完成，但所有数据源都未命中 |
+| `upstream_unavailable` | **是** | 1 | OpenAlex API 瞬时失败；稍后重试或使用 `--offline` |
+| `file_not_found` / `validation_error` | 否 | 2 | 输入不合法 |
+| `runtime_error` | 是 | 1 | 未预期的内部错误 |
+
+请基于 `error.code` + `error.retryable` 来分支重试逻辑，不要只看退出码 —— 退出
+`1` 同时覆盖瞬时错误和运行时错误。可用 `--format json|table|human` 强制格式
+（`--json` 是旧版兼容别名）；所有全局参数可以放在子命令前或后。
+
+### 影响因子解读
+
+| IF 范围 | 典型层级 | 示例 |
+| --------- | --------- | ------ |
+| > 30 | 顶级（前 0.1%） | Nature (64.8)、Science (56.9)、Cell (64.5) |
+| 20–30 | 卓越（前 1%） | Cancer Cell (50.3)、Immunity (32.4) |
+| 10–20 | 优秀（前 5%） | Nature Communications (16.6)、Sci Adv (13.6) |
+| 5–10 | 良好（前 15%） | eLife (7.7)、Cell Reports (8.8) |
+| 2–5 | 扎实 | PLOS ONE (3.7)、Sci Rep (4.6) |
+| < 2 | 细分/新刊 | 许多领域专刊和新创期刊 |
+
+**注意：** 影响因子因学科差异巨大 —— 请始终在同一领域内比较。
+OpenAlex 近似 IF 与官方 JCR IF 不同；用于排名参考，不用于正式引用。
+
+## 依赖
+
+- Python 3.9+（无需安装第三方包）
+
+## ❤️ 支持
+
+如果这个技能对你有帮助，欢迎打赏支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="打赏">
+      <br>
+      <b>打赏</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 作者
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- B站: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+CC BY-NC 4.0 — 非商业用途免费。商业用途需授权。

--- a/plugins/journal-meta/LICENSE
+++ b/plugins/journal-meta/LICENSE
@@ -1,0 +1,28 @@
+Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+
+Copyright (c) 2026 Agents365-ai
+
+This work is licensed under the Creative Commons Attribution-NonCommercial 4.0
+International License. To view a copy of this license, visit:
+http://creativecommons.org/licenses/by-nc/4.0/ or send a letter to
+Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+You are free to:
+  - Share — copy and redistribute the material in any medium or format
+  - Adapt — remix, transform, and build upon the material
+
+Under the following terms:
+  - Attribution — You must give appropriate credit, provide a link to the
+    license, and indicate if changes were made. You may do so in any
+    reasonable manner, but not in any way that suggests the licensor
+    endorses you or your use.
+  - NonCommercial — You may not use the material for commercial purposes.
+
+Notices:
+  - You do not have to comply with the license for elements of the material
+    in the public domain or where your use is permitted by an applicable
+    exception or limitation.
+  - No warranties are given. The license may not give you all of the
+    permissions necessary for your intended use. For example, other rights
+    such as publicity, privacy, or moral rights may limit how you use
+    the material.

--- a/plugins/journal-meta/README.md
+++ b/plugins/journal-meta/README.md
@@ -1,0 +1,135 @@
+# Journal Meta — Paper Metadata Lookup Skill
+
+[![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/journal-meta?style=flat&logo=github)](https://github.com/Agents365-ai/journal-meta/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/journal-meta?style=flat&logo=github)](https://github.com/Agents365-ai/journal-meta/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/journal-meta?logo=github)](https://github.com/Agents365-ai/journal-meta/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/journal-meta?logo=github)](https://github.com/Agents365-ai/journal-meta/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
+[中文](README_CN.md)
+
+A Claude Code skill that turns a single paper identifier — **DOI, PMID, arXiv id,
+OpenAlex id, or title** — into one complete metadata record: title, full author
+list, first author, corresponding author(s), publication date, journal name +
+ISO-4 abbreviation, impact factor, volume/issue/pages, DOI/PMID, citation count,
+and abstract.
+
+## Workflow
+
+![Journal Meta workflow](docs/workflow.drawio.png)
+
+## Why
+
+| Field | Native Claude Code | Journal Meta |
+| ------- | -------------------- | -------------- |
+| Title / authors / date / venue | Guessed from memory | Resolved from OpenAlex (+ Crossref fallback) |
+| First author | Ambiguous | `author_position == first` |
+| Corresponding author | Not available | OpenAlex `is_corresponding` (never guessed) |
+| Journal abbreviation | Manual guessing | Delegated to **journal-abbrev** (ISO-4, ~25K journals) |
+| Impact factor | Not available | Delegated to **journal-if** (curated JCR) |
+| Batch of DOIs/PMIDs | Not supported | `batch file.txt` |
+
+## How it works
+
+1. **OpenAlex** (free, no key) resolves the identifier and supplies nearly every
+   field, including the corresponding-author flag. **Crossref** is a fallback for
+   DOIs OpenAlex hasn't indexed yet.
+2. The journal name is enriched by **delegating to two sibling skills** when they
+   are installed:
+   - [`journal-abbrev`](https://github.com/Agents365-ai/journal-abbrev) → ISO-4 abbreviation.
+   - [`journal-if`](https://github.com/Agents365-ai/journal-if) → curated JCR impact factor.
+   - Fallbacks (AbbrevISO, OpenAlex 2-year mean citedness) kick in automatically
+     if those skills aren't found. `meta.sources` always tells you which was used.
+
+## Usage
+
+```bash
+# From a DOI
+python3 journal_meta.py "10.1038/s41586-020-2649-2"
+
+# From a PMID / arXiv id / title
+python3 journal_meta.py 32939066
+python3 journal_meta.py 1706.03762
+python3 journal_meta.py "Attention is all you need"
+
+# A list, one identifier per line
+python3 journal_meta.py batch papers.txt
+
+# Skip enrichment, or force JSON
+python3 journal_meta.py <id> --no-if --no-abbrev
+python3 journal_meta.py <id> --format json
+```
+
+Output is a human key-value view on a TTY and a stable JSON envelope when piped.
+`meta.sources` records the provenance of the abbreviation and impact factor.
+
+## Configuration
+
+| Env var | Effect |
+| --------- | -------- |
+| `JOURNAL_META_MAILTO` / `OPENALEX_MAILTO` | Email for OpenAlex's polite pool (recommended). |
+| `JOURNAL_ABBREV_CLI` | Explicit path to `journal-abbrev`'s `jabbrv.py`. |
+| `JOURNAL_IF_CLI` | Explicit path to `journal-if`'s `journal_if.py`. |
+
+## Caveats
+
+- **Corresponding author** relies on OpenAlex's `is_corresponding` flag, which is
+  only present when the publisher supplied it — an empty list means "not marked,"
+  not "none." The skill never infers one.
+- **Impact factor** from `journal-if` is the curated JCR value; the fallback is an
+  OpenAlex approximation and is labelled as such in `impact_factor_source`.
+- **Title search** returns OpenAlex's single top hit; prefer a DOI or PMID for the
+  version of record.
+
+## Requirements
+
+- Python 3 (standard library only — no third-party packages).
+- Optional but recommended: the `journal-abbrev` and `journal-if` skills installed
+  alongside this one for curated abbreviations and impact factors.
+
+**Works with:** Claude Code and any coding agent that can run a Python CLI.
+
+## ❤️ Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="Give a Reward">
+      <br>
+      <b>Give a Reward</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 Author
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+CC BY-NC 4.0 — Free for non-commercial use. Commercial use requires permission.

--- a/plugins/journal-meta/README_CN.md
+++ b/plugins/journal-meta/README_CN.md
@@ -1,0 +1,128 @@
+# Journal Meta — 论文元数据查询技能
+
+[![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/journal-meta?style=flat&logo=github)](https://github.com/Agents365-ai/journal-meta/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/journal-meta?style=flat&logo=github)](https://github.com/Agents365-ai/journal-meta/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/journal-meta?logo=github)](https://github.com/Agents365-ai/journal-meta/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/journal-meta?logo=github)](https://github.com/Agents365-ai/journal-meta/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
+[English](README.md)
+
+一个 Claude Code 技能：只需一个论文标识（**DOI、PMID、arXiv id、OpenAlex id 或标题**），
+即可返回完整的元数据记录——标题、全部作者、第一作者、通讯作者、发表日期、期刊名称与
+ISO-4 缩写、影响因子、卷/期/页码、DOI/PMID、被引次数和摘要。
+
+## 工作流程
+
+![Journal Meta 工作流程](docs/workflow_CN.drawio.png)
+
+## 为什么需要它
+
+| 字段 | 原生 Claude Code | Journal Meta |
+| ------ | ------------------ | -------------- |
+| 标题 / 作者 / 日期 / 期刊 | 凭记忆猜测 | 从 OpenAlex 解析（Crossref 兜底） |
+| 第一作者 | 不明确 | `author_position == first` |
+| 通讯作者 | 无法获取 | OpenAlex `is_corresponding`（绝不臆测） |
+| 期刊缩写 | 人工猜测 | 委托 **journal-abbrev**（ISO-4，约 2.5 万期刊） |
+| 影响因子 | 无法获取 | 委托 **journal-if**（JCR 精选数据） |
+| 批量 DOI/PMID | 不支持 | `batch file.txt` |
+
+## 工作原理
+
+1. **OpenAlex**（免费、无需密钥）解析标识并提供几乎所有字段，包括通讯作者标记；
+   对 OpenAlex 尚未收录的 DOI，用 **Crossref** 兜底。
+2. 期刊名称在两个同级技能已安装时**委托它们**做增强：
+   - [`journal-abbrev`](https://github.com/Agents365-ai/journal-abbrev) → ISO-4 期刊缩写；
+   - [`journal-if`](https://github.com/Agents365-ai/journal-if) → JCR 精选影响因子；
+   - 若未找到这两个技能，则自动回退到 AbbrevISO（缩写）与 OpenAlex 两年平均被引
+     （近似影响因子）。`meta.sources` 始终标明数据来源。
+
+## 用法
+
+```bash
+# 通过 DOI
+python3 journal_meta.py "10.1038/s41586-020-2649-2"
+
+# 通过 PMID / arXiv id / 标题
+python3 journal_meta.py 32939066
+python3 journal_meta.py 1706.03762
+python3 journal_meta.py "Attention is all you need"
+
+# 批量，每行一个标识
+python3 journal_meta.py batch papers.txt
+
+# 跳过增强，或强制 JSON 输出
+python3 journal_meta.py <id> --no-if --no-abbrev
+python3 journal_meta.py <id> --format json
+```
+
+在终端下输出人类可读的键值视图，管道/捕获时输出稳定的 JSON 信封。
+`meta.sources` 记录缩写与影响因子的具体来源。
+
+## 配置
+
+| 环境变量 | 作用 |
+| ---------- | ------ |
+| `JOURNAL_META_MAILTO` / `OPENALEX_MAILTO` | OpenAlex 礼貌池所用邮箱（推荐设置）。 |
+| `JOURNAL_ABBREV_CLI` | `journal-abbrev` 的 `jabbrv.py` 显式路径。 |
+| `JOURNAL_IF_CLI` | `journal-if` 的 `journal_if.py` 显式路径。 |
+
+## 注意事项
+
+- **通讯作者**依赖 OpenAlex 的 `is_corresponding` 标记，仅当出版商提供时才有——
+  空列表意味着「元数据未标注」，而非「没有通讯作者」。本技能绝不臆测。
+- **影响因子**来自 `journal-if` 时为 JCR 精选值；回退值为 OpenAlex 近似值，并在
+  `impact_factor_source` 中明确标注。
+- **标题检索**只取 OpenAlex 排名第一的结果；如需正式版本，请优先用 DOI 或 PMID。
+
+## 依赖
+
+- Python 3（仅标准库，无需第三方包）。
+- 推荐同时安装 `journal-abbrev` 与 `journal-if` 技能，以获得精选的缩写与影响因子。
+
+**兼容：** Claude Code 以及任何可运行 Python CLI 的编码代理。
+
+## ❤️ 支持
+
+如果这个技能对你有帮助，欢迎支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="打赏">
+      <br>
+      <b>打赏鼓励</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 作者
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 许可证
+
+CC BY-NC 4.0 — 非商业用途免费，商业用途需获得授权。


### PR DESCRIPTION
Restore README.md / README_CN.md / LICENSE at the plugin root for journal-meta and journal-if, pulled from their source repos (Agents365-ai/journal-meta, Agents365-ai/journal-if), matching PR #31 for the other moved plugins. journal-abbrev's repo was not found on GitHub (404), so it is skipped. Do not merge; awaiting review.