### PR TITLE
Move bbc-skill into plugins (bbc v1.0.4) and register in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,26 @@
   },
   "plugins": [
     {
+      "name": "bbc",
+      "source": "./plugins/bbc",
+      "description": "Fetch Bilibili (哔哩哔哩) video comments for UP主 self-analysis. Collect, download, export, and analyze comments on a Bilibili video (BV号 / URL / UID), producing JSONL + summary.json suitable for further analysis (sentiment, keywords, audience trends). Read-only; does not post/edit/delete.",
+      "version": "1.0.4",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/bbc-skill",
+      "license": "MIT",
+      "keywords": [
+        "bilibili",
+        "comments",
+        "scraping",
+        "data",
+        "jsonl",
+        "chinese",
+        "social-media"
+      ]
+    },
+    {
       "name": "drawio",
       "source": "./plugins/drawio",
       "description": "Draw.io diagrams — generate .drawio XML, export to PNG/SVG/PDF via local CLI, with visual review loop and editable embedded XML",

--- a/plugins/bbc/LICENSE
+++ b/plugins/bbc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/bbc/README.md
+++ b/plugins/bbc/README.md
@@ -1,0 +1,351 @@
+# bbc-skill · Bilibili Comment Collector
+
+[中文文档](README_CN.md)
+
+> Built for Bilibili UP主 (content creators): fetch every comment on your own
+> videos and feed them to Claude Code / Codex / Gemini / any agent for
+> sentiment / keyword / audience analysis.
+
+- 🐍 **Zero dependencies** — Python 3.9+ standard library only, no `pip install`
+- 💬 **Complete** — top-level + nested + pinned comments, nothing skipped
+- 📊 **Video metadata** — title, view/like/coin/favorite counts, tags included
+- 🤖 **Agent-native CLI** — stable stdout JSON envelope, NDJSON stderr
+  progress, distinct exit codes, dry-run, schema introspection
+- 🧑‍🎤 **Batch mode** — fetch every video of a UP主 sequentially (one at a time,
+  5-10s randomised cooldown between videos)
+- 🔐 **Delegated auth** — human logs in once, agent just consumes the cookie;
+  no browser automation
+- ♻️ **Resumable** — re-running the same BV skips completed pages; `--since`
+  for incremental monitoring
+- 📁 **Analysis-friendly** — `comments.jsonl` + `summary.json` + `raw/` archive
+
+## ⚠️ Responsible Use
+
+**Please read and accept these guidelines before using this tool.**
+
+- ✅ **Personal, low-volume, legal use only**: analyze comments on **your own**
+  videos, or assist another creator with their explicit authorization.
+- ✅ **Respect the built-in throttling**: 1s per request, 5-10s random
+  cooldown between videos in batch mode. Do not patch these out.
+- ❌ **Do NOT use for**:
+  - Mass-scraping strangers' videos
+  - Building derivative data products for resale or public redistribution
+  - Bypassing rate limits, spoofing User-Agents, using proxy pools to evade
+    anti-bot systems
+  - High-frequency automation (e.g. daily full re-scans of the same channel)
+  - Harassment, doxxing, coordinated attacks, or targeting specific users
+- 📜 **Comply with Bilibili's ToS** and [robots.txt](https://www.bilibili.com/robots.txt).
+  For commercial/organization use, switch to the official
+  [Bilibili Open Platform](https://openhome.bilibili.com/) APIs.
+- 🔒 **Data minimization**: fetch → analyze → delete. Do not retain raw data
+  long-term, and do not share files containing user IDs or IP locations.
+- 🎯 **The tool is designed for one-shot analyses**, not long-term
+  surveillance.
+
+> This project is not affiliated with bilibili.com. Any account-level risk
+> control, bans, or legal consequences are the user's responsibility. When
+> in doubt about whether a specific use case is allowed — **don't run it**.
+
+---
+
+## Install
+
+It is a plain, self-contained skill: Python 3.9+ stdlib only, zero pip
+install. Clone it into any coding-agent skills directory and it works:
+
+```bash
+# Global (Claude Code example; other agents read their own skills path)
+git clone https://github.com/Agents365-ai/bbc-skill.git ~/.claude/skills/bbc-skill
+
+# Project-level
+git clone https://github.com/Agents365-ai/bbc-skill.git .claude/skills/bbc-skill
+```
+
+Or run it standalone without any skill runtime:
+
+```bash
+git clone https://github.com/Agents365-ai/bbc-skill.git && cd bbc-skill
+./scripts/bbc --help
+```
+
+---
+
+## Quick start
+
+### Step 1 · Export your Bilibili cookie
+
+Bilibili's comment API rate-limits and returns thin data for unauthenticated
+requests. For full UP主 analysis you must authenticate with a cookie.
+
+**Recommended**: the open-source Chrome extension
+[**Get cookies.txt LOCALLY**](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
+— runs entirely locally, uploads nothing.
+
+1. Install **Get cookies.txt LOCALLY** from the Chrome Web Store.
+2. Visit [https://www.bilibili.com](https://www.bilibili.com) and confirm you
+   are logged in (avatar visible top-right).
+3. Click the extension icon → **Export** → download
+   `www.bilibili.com_cookies.txt`.
+4. Save it somewhere convenient, e.g. `~/Downloads/bilibili_cookies.txt`.
+
+**Other options**:
+
+- Firefox: [cookies.txt](https://addons.mozilla.org/firefox/addon/cookies-txt/)
+  add-on.
+- Edge: the same Chrome extension works.
+- Manual: DevTools F12 → Application → Cookies → copy the `SESSDATA` value,
+  then `export BBC_SESSDATA="<value>"`.
+
+**Do not share `SESSDATA`** — it authorizes full account access.
+
+### Step 2 · Verify the cookie works
+
+```bash
+./scripts/bbc cookie-check --cookie-file ~/Downloads/bilibili_cookies.txt
+```
+
+Expected:
+
+```json
+{"ok": true, "data": {"mid": 441831884, "uname": "探索未至之境", "vip": true, "level": 5, ...}}
+```
+
+If it fails: confirm you are currently logged in at bilibili.com, re-export
+the cookie, and retry.
+
+### Step 3 · Fetch comments
+
+```bash
+./scripts/bbc fetch BV1NjA7zjEAU \
+  --cookie-file ~/Downloads/bilibili_cookies.txt
+```
+
+URLs are accepted too:
+
+```bash
+./scripts/bbc fetch "https://www.bilibili.com/video/BV1NjA7zjEAU/"
+```
+
+Output lives in `./bilibili-comments/BV1NjA7zjEAU/`:
+
+```
+bilibili-comments/BV1NjA7zjEAU/
+├── comments.jsonl      # flat JSONL — one comment per line
+├── summary.json        # video meta + aggregated stats + top-N
+├── raw/                # archived API responses
+└── .bbc-state.json     # resume / incremental state
+```
+
+---
+
+## Environment variables
+
+```bash
+export BBC_COOKIE_FILE="$HOME/Downloads/bilibili_cookies.txt"
+./scripts/bbc fetch BV1NjA7zjEAU
+```
+
+Or pass `SESSDATA` directly:
+
+```bash
+export BBC_SESSDATA="<value from DevTools>"
+./scripts/bbc fetch BV1NjA7zjEAU
+```
+
+---
+
+## Analysis workflow with Claude Code
+
+After fetch completes, ask Claude something like:
+
+> Read `./bilibili-comments/BV1NjA7zjEAU/summary.json` first — give me the
+> overall picture: video stats, comment distribution, top 20 liked. Then
+> I'll direct what to analyze next.
+
+Claude follows this path:
+
+1. **Read `summary.json` first** (a few KB) — video title, stats, time
+   distribution, IP distribution, top-N comments.
+2. **Sample `comments.jsonl` on demand** — each line is a flat JSON record;
+   `Grep` for keywords, `head/tail` for chronology, sort by `like` for
+   hot-comment analysis.
+3. **Typical analyses**:
+   - Sentiment: positive / negative / neutral ratio
+   - Keyword frequency (excluding stopwords)
+   - UP interaction audit: filter `is_up_reply=true`, see which threads you
+     replied to vs. missed
+   - Geographic breakdown from `ip_location`
+   - Feedback evolution: bucket `ctime_iso` by week/month
+   - Super-fan detection: group by `mid`, rank by comment count
+   - Negative-review triage: high `like` + negative keywords
+
+---
+
+## Commands
+
+### `bbc fetch <BV|URL>`
+
+```
+--max N                 Cap top-level comments (default: all)
+--since <date>          Only fetch comments newer than this (ISO, e.g. 2026-04-01)
+--output <dir>          Output directory (default ./bilibili-comments/<BV>/)
+--cookie-file <path>    Netscape cookie file
+--browser <name>        auto / firefox / chrome / edge / safari
+--format json|table     stdout format
+--dry-run               Preview request plan, no network calls
+--force                 Ignore resume state, refetch everything
+```
+
+### `bbc fetch-user <UID>`
+
+Batch fetch across a UP主's entire video catalog, sequential with a randomised
+5-10s cooldown between videos.
+
+```bash
+python3 -m bbc fetch-user 441831884 --cookie-file cookies.txt
+python3 -m bbc fetch-user 441831884 --video-limit 2   # dry-run / small batches
+```
+
+### `bbc summarize <dir>`
+
+Rebuild `summary.json` from an existing `comments.jsonl`.
+
+### `bbc cookie-check`
+
+Validate the cookie and print the logged-in user.
+
+### `bbc schema [command]`
+
+Return JSON schema for a command (param types, exit codes, error codes).
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Runtime / API error |
+| 2 | Auth error (cookie invalid / missing) |
+| 3 | Validation error (bad parameter) |
+| 4 | Network error (timeout / retries exhausted) |
+
+---
+
+## Output schemas
+
+### `comments.jsonl` record
+
+```json
+{
+  "rpid": 296636680849,
+  "bvid": "BV1NjA7zjEAU",
+  "parent": 0,
+  "root": 0,
+  "mid": 71171081,
+  "uname": "user nickname",
+  "user_level": 4,
+  "vip": false,
+  "ctime": 1776521119,
+  "ctime_iso": "2026-04-18T06:25:19+00:00",
+  "message": "...",
+  "like": 1,
+  "rcount": 0,
+  "ip_location": "河北",
+  "is_up_reply": false,
+  "top_type": 0,
+  "mentioned_users": [],
+  "jump_urls": []
+}
+```
+
+- `parent=0` → top-level; otherwise `rpid` of the parent comment
+- `top_type`: 0=normal, 1=UP pinned, 2=editor pinned
+- `is_up_reply`: true if the comment was authored by the video owner
+
+### `summary.json` fields
+
+- `video`: title, description, stats, tags, cover URL, owner
+- `counts`: total, top-level, nested, pinned, unique users, UP replies,
+  completeness ratio
+- `time_distribution`: earliest/latest timestamps, daily histogram
+- `top_liked`: top-N comments by like count
+- `top_replied`: top-N top-level comments by reply count
+- `ip_distribution`: histogram of IP provinces
+
+See `references/agent-contract.md` for the full schema.
+
+---
+
+## Limits & caveats
+
+- **Read-only** — never posts, edits, or deletes. Safety tier: `open`.
+- **Rate** — 1s between top-level requests, 0.5s for nested. ~5000 comments
+  takes 10-15 minutes.
+- **Anti-bot** — HTTP 412 triggers exponential backoff (3 retries).
+- **Completeness** — the `completeness` field in `summary.json` compares
+  fetched vs. declared counts; values below 1.0 indicate deleted comments
+  or API inconsistency.
+- **Anonymous not supported** — UP主 analysis requires a valid cookie.
+
+---
+
+## References
+
+- [SKILL.md](./SKILL.md) — skill trigger + usage guide for Claude
+- [references/api-endpoints.md](./references/api-endpoints.md) — Bilibili
+  API fields used
+- [references/agent-contract.md](./references/agent-contract.md) — envelope /
+  exit code / schema contract
+
+---
+
+## Contributing
+
+Suggestions, bug reports, and pull requests are all welcome. If you have
+ideas — new analysis workflows, better anti-bot defaults, additional
+platform support, documentation fixes — feel free to
+[open an issue](https://github.com/Agents365-ai/bbc-skill/issues) or
+submit a PR directly.
+
+This skill is community-friendly: every contribution, no matter how small,
+helps make it better for everyone.
+
+---
+
+## Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+---
+
+## Author
+
+**Agents365-ai** &mdash; building open-source skills for AI coding agents.
+
+- Bilibili: <https://space.bilibili.com/441831884>
+- GitHub: <https://github.com/Agents365-ai>
+
+---
+
+## License
+
+MIT

--- a/plugins/bbc/README_CN.md
+++ b/plugins/bbc/README_CN.md
@@ -1,0 +1,312 @@
+# bbc-skill · 哔哩哔哩评论采集
+
+[English README](README.md)
+
+> UP 主专属：一键拉取自己视频的全部评论，交给 Claude Code / Codex / Gemini / 任何 agent 做情感 / 关键词 / 受众分析。
+
+- 🐍 **零依赖** — 只用 Python 3.9+ 标准库，不需要 `pip install`
+- 💬 **完整评论** — 顶级评论 + 楼中楼 + 置顶评论，一条不落
+- 📊 **视频元数据** — 标题、播放、点赞、投币、收藏、标签一起拉
+- 🤖 **Agent-native CLI** — stdout 稳定 JSON envelope，stderr NDJSON 进度，exit code 分类、dry-run、schema 自描述
+- 🧑‍🎤 **批量模式** — 一个命令拉 UP 主全部视频评论，串行处理（一个视频一个视频来，视频之间随机休眠 5-10s）
+- 🔐 **认证委托** — 人登录 / agent 使用；纯 cookie 文件，不做浏览器自动化
+- ♻️ **断点续传** — 重跑同一 BV 自动跳过已拉页；`--since` 支持增量
+- 📁 **分析友好输出** — `comments.jsonl` + `summary.json` + `raw/` 归档
+
+## ⚠️ 合理使用声明
+
+**请阅读并遵守以下准则，否则请不要使用本工具。**
+
+- ✅ **仅限个人、少量、合法使用**：分析**你自己**视频的评论，或获得 UP 主明确授权后协助分析。
+- ✅ **保持节制**：批量模式已内置 5-10s 随机间隔和 1s 每请求节流；请不要修改源码绕过这些限制。
+- ❌ **禁止滥用场景**：
+  - 大规模爬取陌生 UP 的视频评论
+  - 构建二级数据产品对外出售 / 公开发布
+  - 绕过速率限制、伪造 User-Agent、使用代理池规避风控
+  - 高频自动化任务（每日多次全量扫描同一 UP 主的所有视频）
+  - 把采集到的数据用于骚扰、网络暴力、人肉、定向引战
+- 📜 **遵守 B 站用户协议** 与 [robots](https://www.bilibili.com/robots.txt)；商业场景请走 [B 站开放平台](https://openhome.bilibili.com/) 官方 API。
+- 🔒 **数据最小化原则**：拉完就分析；不要无限期留存、也不要把含用户个人信息（UID、IP 属地）的 raw 数据分享出去。
+- 🎯 **读完即删的工作流更健康**：本工具设计就是为了「一次分析一批视频」，不是为了搞长期监控。
+
+> 本项目作者与 bilibili.com 无任何关联。使用本工具造成的任何账号风控、封禁、法律后果由使用者自行承担。如果你不确定某个使用场景是否合规，**请不要跑**。
+
+---
+
+## 安装
+
+这是一个纯自包含的常规 skill:只用 Python 3.9+ 标准库，零 `pip install`。
+任意 coding agent 的 skill 目录，clone 进去就能用：
+
+```bash
+# 全局（以 Claude Code 为例；其他 agent 用各自的 skills 路径）
+git clone https://github.com/Agents365-ai/bbc-skill.git ~/.claude/skills/bbc-skill
+
+# 项目级
+git clone https://github.com/Agents365-ai/bbc-skill.git .claude/skills/bbc-skill
+```
+
+不走 skill 运行时、直接命令行用也可以：
+
+```bash
+git clone https://github.com/Agents365-ai/bbc-skill.git && cd bbc-skill
+./scripts/bbc --help
+```
+
+---
+
+## 一分钟上手
+
+### 第 1 步 · 导出 B 站 cookie
+
+> **为什么要 cookie**：B 站评论 API 对未登录请求会限速且缺字段。UP 主做自己视频分析需要完整数据，所以必须带 cookie。
+
+**推荐方式**：Chrome 插件 [**Get cookies.txt LOCALLY**](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)（开源、完全本地、不上传任何数据）。
+
+1. Chrome 商店安装 **Get cookies.txt LOCALLY**
+2. 打开 [https://www.bilibili.com](https://www.bilibili.com)，**确认自己已登录**（右上角有头像）
+3. 点插件图标 → **Export** → 下载 `www.bilibili.com_cookies.txt`
+4. 把文件放到你方便的位置，例如 `~/Downloads/bilibili_cookies.txt`
+
+**其他导出方式**：
+
+- Firefox：安装 [cookies.txt](https://addons.mozilla.org/firefox/addon/cookies-txt/) 插件，操作类似
+- Edge：同 Chrome 插件（Edge 兼容 Chrome 扩展）
+- 命令行手动：浏览器 F12 → Application → Cookies → 复制 `SESSDATA` 值，然后 `export BBC_SESSDATA="值"`
+
+**不要**分享 `SESSDATA` —— 泄露等于账号被盗。
+
+### 第 2 步 · 验证 cookie 能用
+
+```bash
+./scripts/bbc cookie-check --cookie-file ~/Downloads/bilibili_cookies.txt
+```
+
+期望输出：
+
+```json
+{"ok": true, "data": {"mid": 441831884, "uname": "探索未至之境", "vip": true, "level": 5, ...}}
+```
+
+失败？检查：
+
+- 确认 bilibili.com **当前已登录**（cookie 导出时处于登录态）
+- `SESSDATA` 不要手动改动
+- 两周未登录可能过期，重新登录一次再导出
+
+### 第 3 步 · 拉你的视频评论
+
+```bash
+./scripts/bbc fetch BV1NjA7zjEAU \
+  --cookie-file ~/Downloads/bilibili_cookies.txt
+```
+
+也可以直接传 URL：
+
+```bash
+./scripts/bbc fetch "https://www.bilibili.com/video/BV1NjA7zjEAU/"
+```
+
+输出在 `./bilibili-comments/BV1NjA7zjEAU/`：
+
+```
+bilibili-comments/BV1NjA7zjEAU/
+├── comments.jsonl      # 主数据，每行一条评论
+├── summary.json        # 视频元数据 + 统计 + Top-N
+├── raw/                # 原始 API 响应归档
+└── .bbc-state.json     # 断点 & 增量标记
+```
+
+---
+
+## 环境变量（免反复传参）
+
+```bash
+export BBC_COOKIE_FILE="$HOME/Downloads/bilibili_cookies.txt"
+./scripts/bbc fetch BV1NjA7zjEAU      # 自动读取
+```
+
+或者直接传 SESSDATA：
+
+```bash
+export BBC_SESSDATA="从 F12 复制的值"
+./scripts/bbc fetch BV1NjA7zjEAU
+```
+
+---
+
+## 给 Claude Code 用的分析工作流
+
+拉完之后告诉 Claude：
+
+> 读取 `./bilibili-comments/BV1NjA7zjEAU/summary.json`，先给我看整体情况：视频基础数据、评论分布、Top 20 热评。然后我会告诉你接下来分析什么。
+
+Claude 会按这个路径做：
+
+1. **先读 `summary.json`**（几 KB）建立全局认知：视频标题、播放量、评论数、时间分布、IP 分布、Top-N 热评 / 回复数
+2. **按需采样 `comments.jsonl`** —— 每行一条 JSON，可以 `Grep` 关键词、`head`/`tail` 看最新最早、按 `like` 排序取头部
+3. **典型分析方向**：
+   - **情感倾向**：正面 / 负面 / 中性占比
+   - **高频词**：除了停用词以外的主题词
+   - **UP 主互动**：`is_up_reply=true` 的评论，看你回了哪些、哪些漏回
+   - **地域分布**：`ip_location` 直方图
+   - **反馈演变**：按 `ctime_iso` 分周 / 月，看发布后一周 vs 长尾
+   - **铁粉识别**：按 `mid` 聚合，同一用户评论多次的名单
+   - **差评筛查**：`like` 高且含 "垃圾/太水/不行" 类词的评论
+
+---
+
+## 命令参考
+
+### `bbc fetch <BV|URL>`
+
+```
+--max N                每个视频顶级评论上限（默认全拉）
+--since <日期>         只拉这个时间后的新评论（ISO 格式，如 2026-04-01）
+--output <dir>         输出目录（默认 ./bilibili-comments/<BV>/）
+--cookie-file <path>   cookie 文件路径
+--browser <name>       auto / firefox / chrome / edge / safari
+--format json|table    stdout 格式
+--dry-run              预览请求计划，不发网络
+--force                忽略断点，重头抓
+```
+
+### `bbc fetch-user <UID>`
+
+批量拉 UP 主所有视频的评论，串行处理，视频之间随机休眠 5-10s。
+
+```bash
+python3 -m bbc fetch-user 441831884 --cookie-file cookies.txt
+python3 -m bbc fetch-user 441831884 --video-limit 2   # 先小批量试跑
+```
+
+### `bbc summarize <dir>`
+
+从已有 `comments.jsonl` 重建 `summary.json`（当你手动修改了原始数据时有用）。
+
+### `bbc cookie-check`
+
+验证 cookie 可用性，打印登录用户信息。
+
+### `bbc schema [command]`
+
+返回命令的 JSON schema（参数类型、exit code 映射、错误码）。供 agent 自描述用。
+
+### Exit codes
+
+| 码 | 含义 |
+| --- | --- |
+| 0 | 成功 |
+| 1 | 运行时 / B站 API 错误 |
+| 2 | 认证错误（cookie 无效 / 过期） |
+| 3 | 参数校验错误（BV 格式错等） |
+| 4 | 网络错误（超时、重试耗尽） |
+
+---
+
+## 输出格式说明
+
+### `comments.jsonl` 单条记录
+
+```json
+{
+  "rpid": 296636680849,
+  "bvid": "BV1NjA7zjEAU",
+  "parent": 0,
+  "root": 0,
+  "mid": 71171081,
+  "uname": "蓝忘今宵-_-YS",
+  "user_level": 4,
+  "vip": false,
+  "ctime": 1776521119,
+  "ctime_iso": "2026-04-18T06:25:19+00:00",
+  "message": "已关注 求指教",
+  "like": 1,
+  "rcount": 0,
+  "ip_location": "河北",
+  "is_up_reply": false,
+  "top_type": 0,
+  "mentioned_users": [],
+  "jump_urls": []
+}
+```
+
+- `parent=0` → 顶级评论；否则指向父评论 rpid
+- `top_type`：0=普通, 1=UP 置顶, 2=热评置顶
+- `is_up_reply`：是否是 UP 主本人回复
+
+### `summary.json` 字段一览
+
+- `video`：标题、简介、播放量、点赞、投币、收藏、标签、封面 URL、UP 主
+- `counts`：总数、顶级数、楼中楼数、置顶数、唯一用户数、UP 回复数、完整度
+- `time_distribution`：最早 / 最晚评论时间、按天分布
+- `top_liked`：Top N 点赞评论
+- `top_replied`：Top N 被回复评论
+- `ip_distribution`：IP 属地分布
+
+详细 schema 见 `references/agent-contract.md`。
+
+---
+
+## 限制 & 注意事项
+
+- **只读** — 本工具不发布 / 修改 / 删除任何评论，安全分层为 `open`
+- **速率** — 每请求间隔 1s（顶级）/ 0.5s（楼中楼），5000 条约 10-15 分钟
+- **反风控** — 连续多次抓取可能触发 HTTP 412，已内建指数退避重试 3 次
+- **完整度** — summary 中 `completeness` 显示实拉 / 接口声称总数；<1.0 说明有被删评论或接口不一致
+- **不支持匿名** — UP 主分析必须带 cookie；未登录请求返回字段不完整
+
+---
+
+## 相关文档
+
+- [SKILL.md](./SKILL.md) — 给 Claude 的触发 & 使用指引
+- [references/api-endpoints.md](./references/api-endpoints.md) — 所用 B 站接口字段
+- [references/agent-contract.md](./references/agent-contract.md) — envelope / exit code / schema 契约
+
+---
+
+## 贡献
+
+欢迎提 issue、PR、建议。无论是新的分析场景、更稳的反风控默认值、其他平台支持、文档改进 —— 任何贡献都欢迎。[提 Issue](https://github.com/Agents365-ai/bbc-skill/issues) 或直接发 PR。
+
+---
+
+## Support
+
+如果这个 skill 帮到了你，可以请作者喝杯咖啡 ☕
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+---
+
+## 作者
+
+**Agents365-ai** &mdash; 为 AI coding agent 制作开源 skill。
+
+- B 站：<https://space.bilibili.com/441831884>
+- GitHub：<https://github.com/Agents365-ai>
+
+---
+
+## License
+
+MIT

--- a/plugins/bbc/skills/bbc-skill/SKILL.md
+++ b/plugins/bbc/skills/bbc-skill/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: bbc-skill
+description: Fetch Bilibili (哔哩哔哩) video comments for UP主 self-analysis. Use when the user asks to collect, download, export, or analyze comments on a Bilibili video (BV号 / URL / UID). Produces JSONL + summary.json suitable for further Claude Code analysis (sentiment, keywords, audience trends). Read-only; does not post/edit/delete.
+license: MIT
+homepage: https://github.com/Agents365-ai/bbc-skill
+metadata: {"version":"1.0.4","openclaw":{"requires":{"bins":["python3"]},"emoji":"💬"},"hermes":{"category":"data","tags":["bilibili","comments","up主","scraping","chinese"]}}
+---
+
+# bbc-skill — Bilibili Comment Collector
+
+Download all comments (top-level + nested + pinned) for a Bilibili video and
+produce data that Claude Code can analyze downstream.
+
+## Update check
+
+Throttle to one check per 24 hours per installation; never mutate the skill directory without explicit user consent.
+
+1. If `<this-skill-dir>/.last_update` exists and is less than 24 hours old, skip this step entirely.
+
+2. Otherwise, fetch the latest tag from upstream:
+
+   ```bash
+   git -C <this-skill-dir> ls-remote --tags origin 'v*' 2>/dev/null \
+     | awk '{print $2}' | sed 's|refs/tags/||' \
+     | sort -V | tail -1
+   ```
+
+3. Compare with this skill's `metadata.version` from the frontmatter. If the upstream tag is strictly newer (semver), tell the user one line and ask:
+
+   > "A newer version of this skill is available: vX.Y.Z → vA.B.C. Want me to `git pull`?"
+
+   If they say yes, run `git -C <this-skill-dir> pull --ff-only`. Refresh `.last_update` either way so the prompt doesn't repeat for 24 hours.
+
+4. If upstream is the same or older, refresh `.last_update` silently and continue.
+
+5. On any failure (offline, not a git checkout — e.g. ClawHub-installed copy, read-only path, no permission), swallow the error silently and continue with the user's task. Do not mention the failure.
+
+## When to use
+
+Trigger this skill when the user:
+
+- Asks to **get / fetch / download / export / collect / analyze** comments of a
+  specific Bilibili video (BV 号, URL, or video page).
+- Asks to analyze **audience feedback / sentiment / keywords / top comments /
+  IP distribution** of their own Bilibili videos.
+- Provides a Bilibili URL like `https://www.bilibili.com/video/BVxxxxxxxxxx/`.
+- Mentions their UP主 UID and wants batch analysis across their videos.
+
+Do **not** use for: posting / deleting comments, downloading videos, barrage
+(弹幕), live stream data, or private messages.
+
+## Prerequisites
+
+1. **Python 3.9+** (stdlib only — zero pip install).
+2. **Bilibili cookie**. The user must be logged in to bilibili.com. The
+   recommended path:
+   - Install the Chrome/Edge extension
+     [**Get cookies.txt LOCALLY**](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
+     (open-source, fully local, no upload).
+   - On a logged-in bilibili.com tab, click **Export** → save
+     `www.bilibili.com_cookies.txt`.
+   - Pass via `--cookie-file` or set `$BBC_COOKIE_FILE`.
+
+   Alternatives:
+   - `$BBC_SESSDATA` env var with just the SESSDATA value.
+   - Browser auto-detection (Firefox / Chrome / Edge on macOS) via
+     `--browser auto`. Works best for Firefox; Chrome/Edge needs a logged-in
+     profile with cookies flushed to disk.
+
+**Auth delegation (Principle 7):** the skill never runs OAuth flows. The human
+is expected to log in via browser; the agent only consumes the resulting
+cookie.
+
+## Quick start
+
+Before any fetch, verify the cookie works:
+
+```bash
+python3 -m bbc cookie-check
+```
+
+Success envelope (stdout):
+
+```json
+{"ok":true,"data":{"mid":441831884,"uname":"探索未至之境","vip":false}}
+```
+
+Fetch all comments for a single video:
+
+```bash
+python3 -m bbc fetch BV1NjA7zjEAU
+```
+
+Or pass a URL:
+
+```bash
+python3 -m bbc fetch "https://www.bilibili.com/video/BV1NjA7zjEAU/"
+```
+
+Output (default `./bilibili-comments/<BV>/`):
+
+- `comments.jsonl` — one comment per line, flattened
+- `summary.json` — video metadata + statistics + top-N
+- `raw/` — archived API responses
+- `.bbc-state.json` — resume state
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `bbc fetch <BV\|URL>` | Fetch all comments for one video |
+| `bbc fetch-user <UID>` | Batch fetch all videos of a UP主 |
+| `bbc summarize <dir>` | Rebuild `summary.json` from existing `comments.jsonl` |
+| `bbc cookie-check` | Validate cookie; print logged-in user |
+| `bbc schema [cmd]` | Return JSON schema for commands (for agent discovery) |
+
+Call `bbc <cmd> --help` or `bbc schema <cmd>` for full parameter details — do
+not guess flag names.
+
+## Agent contract
+
+### Stdout vs stderr
+
+- **stdout**: stable JSON envelope `{"ok":true,"data":...}` or
+  `{"ok":false,"error":...}`. JSON is the default when stdout is not a TTY.
+  Pass `--format table` for human-readable tables.
+- **stderr**: human log lines + NDJSON progress events for long tasks.
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Runtime / API error |
+| 2 | Auth error (cookie invalid / missing) |
+| 3 | Validation error (bad BV number, bad flag) |
+| 4 | Network error (timeout / retries exhausted) |
+
+### Error envelope
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "auth_expired",
+    "message": "SESSDATA 已过期，请重新登录 B 站",
+    "retryable": true,
+    "retry_after_auth": true
+  }
+}
+```
+
+Error codes: `validation_error`, `auth_required`, `auth_expired`, `not_found`,
+`rate_limited`, `api_error`, `network_error`. See `bbc schema` for the full
+contract.
+
+### Dry-run
+
+Every fetch command supports `--dry-run` to preview the planned request
+without making network calls:
+
+```bash
+python3 -m bbc fetch BV1NjA7zjEAU --dry-run
+```
+
+### Idempotency
+
+Re-running the same `fetch` command on the same output directory resumes from
+`.bbc-state.json` (skips already-fetched pages). Pass `--force` to refetch.
+
+## Analysis workflow (for the agent)
+
+After `fetch` completes:
+
+1. **Read `summary.json` first** (< 10 KB) to establish global context: video
+   metadata, total counts, time distribution, top-N.
+2. **For thematic analysis**, `Grep` or `head`/`tail` on `comments.jsonl` —
+   each line is a flat JSON object, never load the whole file unless small.
+3. **Typical analyses**:
+   - Sentiment distribution → scan `message` by batch
+   - Top fans → group by `mid`, count entries, aggregate `like`
+   - UP 主互动 → filter `is_up_reply=true`
+   - Audience geography → `ip_location` histogram
+   - Feedback timeline → bucket `ctime_iso` by day/week
+
+The `summary.json` schema is documented in `references/agent-contract.md`.
+Run the skill against any video to produce a real sample locally.
+
+## Safety tier
+
+All commands are **read-only** (tier: `open`). No mutation, no deletion, no
+message sending. Dry-run available for all fetch commands.
+
+## References
+
+- `references/api-endpoints.md` — Bilibili API fields used
+- `references/cookie-extraction.md` — per-browser cookie decryption
+- `references/agent-contract.md` — full envelope + schema contract
+
+## Limitations
+
+- `all_count` returned by the API includes pinned comments. Completeness
+  check: `top_level + nested + pinned == declared_all_count`.
+- Very old comments (>2 years) may return thin data if the user was deleted.
+- Anti-bot: aggressive `--max` values or repeated runs may trigger HTTP 412.
+  The client sleeps 1s between requests and backs off on 412.

--- a/plugins/bbc/skills/bbc-skill/agent-contract.md
+++ b/plugins/bbc/skills/bbc-skill/agent-contract.md
@@ -1,0 +1,158 @@
+# Agent contract
+
+bbc-skill is designed per the **agent-native CLI** principles: one CLI
+must serve humans, AI agents, and orchestrators simultaneously.
+
+## Channels
+
+| Channel | Content |
+| --- | --- |
+| `stdout` | JSON envelope (one command → one final envelope). Table rendering when stdout is a TTY. |
+| `stderr` | Human log lines + NDJSON progress events for long tasks. |
+| exit code | Numeric class of outcome (see below). |
+
+## Stdout format auto-detection
+
+- If stdout is **not** a TTY (piped / captured / redirected): JSON (one line)
+- If stdout **is** a TTY: human-readable table / indented JSON
+- Override with `--format json` or `--format table`
+
+Agents redirecting output to a file or capturing via `stdout=PIPE` will
+automatically receive parseable JSON without any flag.
+
+## Envelope (success)
+
+```json
+{
+  "ok": true,
+  "data": { ... },
+  "meta": {
+    "request_id": "req_xxx",
+    "latency_ms": 12345,
+    "schema_version": "1.0.0"
+  }
+}
+```
+
+For dry-run commands a top-level `dry_run: true` is also set.
+
+## Envelope (failure)
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "auth_expired",
+    "message": "Cookie 已过期，请重新登录 Bilibili。",
+    "retryable": true,
+    "retry_after_auth": true
+  },
+  "meta": { ... }
+}
+```
+
+### Error codes
+
+| `code` | Exit | Retryable | Meaning |
+| --- | --- | --- | --- |
+| `validation_error` | 3 | no | Bad BV number, bad flag, bad date format |
+| `auth_required` | 2 | yes (after login) | No cookie available |
+| `auth_expired` | 2 | yes (after login) | Cookie rejected by B站 |
+| `not_found` | 1 | no | Video deleted / comment area closed |
+| `rate_limited` | 1 | yes (after backoff) | HTTP 412 / code=-352 / -412 / -509 |
+| `api_error` | 1 | no | B站 returned non-zero `code` |
+| `network_error` | 4 | yes | Timeout / DNS / retries exhausted |
+| `internal_error` | 1 | no | Bug in the skill — please file an issue |
+
+### Retry protocol
+
+- `retryable: false` → do not retry; treat as terminal.
+- `retryable: true` without `retry_after_auth` → safe to retry immediately
+  after backoff.
+- `retryable: true` with `retry_after_auth: true` → prompt the human to
+  re-authenticate (re-export cookie), then retry.
+
+## NDJSON progress events (stderr)
+
+Emitted when `BBC_PROGRESS=1` or when stderr is a TTY. One JSON object per
+line. Schema:
+
+```json
+{"event": "start",    "command": "fetch", "request_id": "...", "elapsed_ms": 0, "bvid": "..."}
+{"event": "progress", "command": "fetch", "request_id": "...", "elapsed_ms": 2294, "phase": "meta", "title": "..."}
+{"event": "progress", "command": "fetch", "request_id": "...", "elapsed_ms": 3437, "phase": "top_level", "page": 2, "done": 20, "cumulative": 39, "declared_total": 59}
+{"event": "progress", "command": "fetch", "request_id": "...", "elapsed_ms": 6186, "phase": "nested", "root_rpid": 299313655152, "page": 1, "got": 1, "cumulative_subs": 1}
+{"event": "complete", "command": "fetch", "request_id": "...", "elapsed_ms": 12237, "counts": {"total": 59, "top_level": 44, "nested": 14, "pinned": 1}}
+```
+
+### Phases
+
+- `meta` — video metadata fetched (BV→aid resolved)
+- `top_level` — a top-level comment page was fetched
+- `nested` — nested replies for a top-level comment were fetched
+- `warn` — non-fatal warnings (e.g. decryption fallback)
+
+Suppression: `BBC_PROGRESS=0` disables progress events.
+
+## Schema introspection
+
+```
+$ bbc schema
+{"ok": true, "data": {"schema_version": "1.0.0", "commands": {...}, ...}}
+
+$ bbc schema fetch
+{"ok": true, "data": {"command": "fetch", "params": {...}, "envelope": {...}, ...}}
+```
+
+The schema output is the source of truth for:
+
+- Parameter types and defaults
+- Exit code mapping
+- Error codes and their retryability
+
+An agent can discover the CLI surface without reading this README.
+
+## Idempotency
+
+All fetch commands are idempotent within an output directory:
+
+- Re-running with the same `--output` reuses `.bbc-state.json` and resumes
+- Pass `--force` to discard state and refetch
+- Same `--since <date>` on repeated runs → incremental monitor mode
+
+There is no `--idempotency-key` flag because:
+
+- The command is read-only (no mutation on the server side)
+- The output directory + resume state serves the same purpose for local
+  correctness
+
+## Auth delegation
+
+The skill **never** runs a browser OAuth flow. The human is responsible
+for:
+
+- Logging into bilibili.com in a browser
+- Exporting the cookie file (see `cookie-extraction.md`)
+
+The agent consumes the cookie via `--cookie-file` / `$BBC_COOKIE_FILE` /
+`$BBC_SESSDATA` / auto-detect. It never invokes an auth retrieval path.
+
+If cookie load fails **and stdin is not a TTY**, `bbc cookie-check` and
+`bbc fetch` return `auth_required` immediately — they never block on an
+interactive prompt.
+
+## Safety tier
+
+All commands are tier = **open** (read-only). Specifically:
+
+- No commands mutate Bilibili state (no post/edit/delete)
+- No commands write outside the user-chosen `--output` directory
+- No subprocess shells out to user-supplied strings
+- Cookie values are never logged to stdout/stderr; only cookie *names* may
+  appear in `cookie-check` output
+
+## Versioning
+
+`schema_version` in every envelope signals breaking-change boundaries.
+Minor version bumps add fields; major version bumps may rename or remove
+fields. Agents that cache schema should compare versions on every run.

--- a/plugins/bbc/skills/bbc-skill/api-endpoints.md
+++ b/plugins/bbc/skills/bbc-skill/api-endpoints.md
@@ -1,0 +1,162 @@
+# Bilibili API endpoints used
+
+All endpoints are HTTP GET with cookie auth. No official SDK — these are
+reverse-engineered from the web client. They are stable in practice but
+undocumented by Bilibili.
+
+## 1. `GET /x/web-interface/view`
+
+Convert `bvid` → `aid`, plus full video metadata.
+
+**Params**
+
+- `bvid` (required)
+
+**Key response fields** (`data`)
+
+- `bvid`, `aid`, `cid` — three ID forms
+- `title`, `desc`, `dynamic` — textual content
+- `pubdate`, `ctime` — Unix timestamps (seconds)
+- `duration` — seconds
+- `tname`, `tid` — category name and id
+- `pic` — cover image URL
+- `owner.mid`, `owner.name`, `owner.face` — UP主 info
+- `stat.view`, `stat.like`, `stat.coin`, `stat.favorite`, `stat.reply`,
+  `stat.danmaku`, `stat.share`, `stat.his_rank`, `stat.now_rank`
+- `staff[]` — collaborative authors (empty if solo)
+
+## 2. `GET /x/web-interface/nav`
+
+Validate cookie / fetch logged-in user info.
+
+**Key response fields** (`data`)
+
+- `isLogin` — bool
+- `mid`, `uname`
+- `level_info.current_level`
+- `vipStatus` — 0/1
+
+Used by `bbc cookie-check`.
+
+## 3. `GET /x/tag/archive/tags`
+
+Fetch tags for a given BV.
+
+**Params**
+
+- `bvid` (required)
+
+**Response**
+
+- `data[]` with `tag_name`, `tag_id`
+
+## 4. `GET /x/v2/reply/main` — top-level comments
+
+Paginated top-level comments.
+
+**Params**
+
+- `type=1` — video (type=11 for article, etc. — not used here)
+- `oid=<aid>` — Note: must use `aid`, not `bvid`
+- `mode=3` — sort by time desc (mode=2 is hot)
+- `next=<cursor>` — pagination cursor (0 for first page)
+- `ps=20` — page size
+
+**Key response fields** (`data`)
+
+- `replies[]` — top-level comments
+- `top_replies[]` — pinned comments (only on first page)
+- `upper.top` — UP主 pinned comment (alternate location)
+- `cursor.next` — next page cursor
+- `cursor.is_end` — true when done
+- `cursor.all_count` — total declared comment count
+
+### Top-level reply fields used
+
+| Path | Meaning |
+| --- | --- |
+| `rpid`, `rpid_str` | Unique comment id (use str for safe JSON) |
+| `oid`, `oid_str` | Video aid |
+| `mid`, `mid_str` | Commenter UID |
+| `parent` | Parent rpid (0 for top-level) |
+| `root` | Root rpid (0 for top-level) |
+| `ctime` | Unix seconds |
+| `like` | Like count |
+| `rcount` | Nested reply count |
+| `member.uname` | Display name |
+| `member.level_info.current_level` | User level 0-6 |
+| `member.sex` | "男" / "女" / "保密" |
+| `member.vip.vipStatus` | 0/1 |
+| `content.message` | Comment text |
+| `content.members[]` | @-mentioned users |
+| `content.jump_url` | Dict of URLs detected in comment |
+| `reply_control.location` | `"IP属地：河北"` — strip prefix |
+| `replies[]` | Inline preview of 1-3 nested replies (not exhaustive) |
+
+## 5. `GET /x/v2/reply/reply` — nested replies
+
+Full nested replies for a given top-level comment.
+
+**Params**
+
+- `type=1`
+- `oid=<aid>`
+- `root=<top-level rpid>`
+- `pn=1` — page number (1-based)
+- `ps=20`
+
+**Response**
+
+- `data.replies[]` — nested replies (same schema as top-level, with
+  `parent`/`root` populated)
+
+Call this for every top-level comment where `rcount > 0`. Stop when the
+returned page has `< 20` replies.
+
+## 6. `GET /x/space/wbi/arc/search` — UP主 video list
+
+List a user's videos (for `fetch-user` batch mode).
+
+**Params**
+
+- `mid=<uid>`
+- `pn=1`, `ps=50`
+- `order=pubdate` — sort by publish date
+
+**Caveat**: this endpoint requires **WBI signing** (MD5 of sorted params +
+mixin key derived from `/x/web-interface/nav`). The current fetcher is
+single-video only; `fetch-user` ships in a later release.
+
+## Error codes observed
+
+| `code` | Meaning | Action |
+| --- | --- | --- |
+| `0` | OK | Proceed |
+| `-101` | Account not logged in | Re-auth (auth_expired) |
+| `-111` | CSRF token invalid | Re-auth |
+| `-352` | Risk control triggered | Retry with backoff |
+| `-412` | Rate limited (request) | Retry with backoff |
+| `-509` | Overloaded | Retry with backoff |
+| `62002` | Comment area closed | not_found |
+| `-404`, `62004` | Resource not found | not_found |
+
+## Pagination details
+
+- **`/x/v2/reply/main`** uses **cursor-based** pagination. `cursor.next` on
+  the current response is the `next` param for the next request. Start with
+  `next=0`. Stop when `cursor.is_end=true` or `replies=[]`.
+- **`/x/v2/reply/reply`** uses **page-number** pagination (`pn=1, 2, ...`).
+  Stop when returned `replies` has fewer than `ps` entries.
+
+## Completeness invariant
+
+The first-page `cursor.all_count` equals:
+
+```
+top_level_count + nested_count + pinned_count
+```
+
+Use this as a self-check after fetching everything — see the
+`completeness` field in `summary.json`. A value below 1.0 usually means
+comments were deleted between pages or a nested page returned
+inconsistent `rcount`.

--- a/plugins/bbc/skills/bbc-skill/bbc/__init__.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/__init__.py
@@ -1,0 +1,2 @@
+__version__ = "1.0.4"
+SCHEMA_VERSION = "1.0.0"

--- a/plugins/bbc/skills/bbc-skill/bbc/__main__.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from bbc.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/bbc/skills/bbc-skill/bbc/api.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/api.py
@@ -1,0 +1,179 @@
+"""HTTP client: stdlib-only, cookie auth, rate-limit, retry."""
+
+import json
+import random
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+# Retryable B站 internal codes
+RETRYABLE_CODES = {-352, -412, -509}
+# Auth-invalid codes
+AUTH_BAD_CODES = {-101, -111}
+NOT_FOUND_CODES = {-404, 62002, 62004}
+
+
+class ApiError(Exception):
+    def __init__(self, code: str, message: str, *, retryable: bool = False, raw: Any = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+        self.raw = raw
+
+
+class Client:
+    def __init__(
+        self,
+        cookies: dict[str, str],
+        *,
+        min_interval_sec: float = 1.0,
+        referer: str = "https://www.bilibili.com/",
+    ):
+        self.cookies = cookies
+        self.min_interval = min_interval_sec
+        self.referer = referer
+        self._last_request = 0.0
+
+    def _cookie_header(self) -> str:
+        return "; ".join(f"{k}={v}" for k, v in self.cookies.items())
+
+    def _throttle(self) -> None:
+        elapsed = time.monotonic() - self._last_request
+        if elapsed < self.min_interval:
+            time.sleep(self.min_interval - elapsed)
+        self._last_request = time.monotonic()
+
+    def get_json(
+        self,
+        url: str,
+        *,
+        max_retries: int = 3,
+        referer: str | None = None,
+    ) -> dict:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": UA,
+                "Cookie": self._cookie_header(),
+                "Referer": referer or self.referer,
+                "Accept": "application/json, text/plain, */*",
+                "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+            },
+        )
+
+        attempt = 0
+        backoff = 2.0
+        while True:
+            attempt += 1
+            self._throttle()
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    raw = resp.read().decode("utf-8")
+                data = json.loads(raw)
+            # pi-lens-ignore: ast-grep:no-boolean-in-except
+            except urllib.error.HTTPError as e:
+                if e.code == 412 and attempt <= max_retries:
+                    time.sleep(backoff + random.random())
+                    backoff *= 2
+                    continue
+                if 500 <= e.code < 600 and attempt <= max_retries:
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                raise ApiError(
+                    "network_error" if e.code >= 500 else "api_error",
+                    f"HTTP {e.code}: {e.reason}",
+                    retryable=(e.code == 412 or 500 <= e.code < 600),
+                )
+            except (urllib.error.URLError, TimeoutError, OSError) as e:
+                if attempt <= max_retries:
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                raise ApiError("network_error", f"{type(e).__name__}: {e}", retryable=True)
+            except json.JSONDecodeError as e:
+                raise ApiError("api_error", f"invalid JSON response: {e}")
+
+            code = data.get("code")
+            if code == 0:
+                return data
+            if code in AUTH_BAD_CODES:
+                raise ApiError("auth_expired", data.get("message") or "cookie rejected", raw=data)
+            if code in NOT_FOUND_CODES:
+                raise ApiError("not_found", data.get("message") or "resource not found", raw=data)
+            if code in RETRYABLE_CODES and attempt <= max_retries:
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            if code in RETRYABLE_CODES:
+                raise ApiError("rate_limited", data.get("message") or "rate limited", retryable=True, raw=data)
+            raise ApiError("api_error", f"B站 code={code}: {data.get('message')}", raw=data)
+
+
+# ---- Endpoint helpers ----
+
+def bv_to_view(client: Client, bvid: str) -> dict:
+    url = f"https://api.bilibili.com/x/web-interface/view?bvid={bvid}"
+    return client.get_json(url)["data"]
+
+
+def get_nav(client: Client) -> dict:
+    return client.get_json("https://api.bilibili.com/x/web-interface/nav")["data"]
+
+
+def get_tags(client: Client, bvid: str) -> list[dict]:
+    url = f"https://api.bilibili.com/x/tag/archive/tags?bvid={bvid}"
+    try:
+        return client.get_json(url).get("data") or []
+    except ApiError:
+        return []
+
+
+def get_main_page(client: Client, aid: int, next_cursor: int, bvid: str, ps: int = 20) -> dict:
+    url = (
+        "https://api.bilibili.com/x/v2/reply/main"
+        f"?type=1&oid={aid}&mode=3&next={next_cursor}&ps={ps}"
+    )
+    return client.get_json(url, referer=f"https://www.bilibili.com/video/{bvid}/")
+
+
+def get_sub_page(client: Client, aid: int, root_rpid: int, pn: int, bvid: str, ps: int = 20) -> dict:
+    url = (
+        "https://api.bilibili.com/x/v2/reply/reply"
+        f"?type=1&oid={aid}&root={root_rpid}&ps={ps}&pn={pn}"
+    )
+    return client.get_json(url, referer=f"https://www.bilibili.com/video/{bvid}/")
+
+
+def list_user_videos(
+    client: Client,
+    uid: int,
+    *,
+    img_key: str,
+    sub_key: str,
+    pn: int = 1,
+    ps: int = 30,
+) -> dict:
+    from bbc import wbi
+
+    params = {
+        "mid": uid,
+        "pn": pn,
+        "ps": ps,
+        "order": "pubdate",
+        "platform": "web",
+        "web_location": "1550101",
+    }
+    url = wbi.signed_url(
+        "https://api.bilibili.com/x/space/wbi/arc/search", params, img_key, sub_key
+    )
+    return client.get_json(url, referer=f"https://space.bilibili.com/{uid}")

--- a/plugins/bbc/skills/bbc-skill/bbc/api.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/api.py
@@ -22,7 +22,9 @@ NOT_FOUND_CODES = {-404, 62002, 62004}
 
 
 class ApiError(Exception):
-    def __init__(self, code: str, message: str, *, retryable: bool = False, raw: Any = None):
+    def __init__(
+        self, code: str, message: str, *, retryable: bool = False, raw: Any = None
+    ):
         super().__init__(message)
         self.code = code
         self.message = message
@@ -99,7 +101,9 @@ class Client:
                     time.sleep(backoff)
                     backoff *= 2
                     continue
-                raise ApiError("network_error", f"{type(e).__name__}: {e}", retryable=True)
+                raise ApiError(
+                    "network_error", f"{type(e).__name__}: {e}", retryable=True
+                )
             except json.JSONDecodeError as e:
                 raise ApiError("api_error", f"invalid JSON response: {e}")
 
@@ -107,19 +111,31 @@ class Client:
             if code == 0:
                 return data
             if code in AUTH_BAD_CODES:
-                raise ApiError("auth_expired", data.get("message") or "cookie rejected", raw=data)
+                raise ApiError(
+                    "auth_expired", data.get("message") or "cookie rejected", raw=data
+                )
             if code in NOT_FOUND_CODES:
-                raise ApiError("not_found", data.get("message") or "resource not found", raw=data)
+                raise ApiError(
+                    "not_found", data.get("message") or "resource not found", raw=data
+                )
             if code in RETRYABLE_CODES and attempt <= max_retries:
                 time.sleep(backoff)
                 backoff *= 2
                 continue
             if code in RETRYABLE_CODES:
-                raise ApiError("rate_limited", data.get("message") or "rate limited", retryable=True, raw=data)
-            raise ApiError("api_error", f"B站 code={code}: {data.get('message')}", raw=data)
+                raise ApiError(
+                    "rate_limited",
+                    data.get("message") or "rate limited",
+                    retryable=True,
+                    raw=data,
+                )
+            raise ApiError(
+                "api_error", f"B站 code={code}: {data.get('message')}", raw=data
+            )
 
 
 # ---- Endpoint helpers ----
+
 
 def bv_to_view(client: Client, bvid: str) -> dict:
     url = f"https://api.bilibili.com/x/web-interface/view?bvid={bvid}"
@@ -138,7 +154,9 @@ def get_tags(client: Client, bvid: str) -> list[dict]:
         return []
 
 
-def get_main_page(client: Client, aid: int, next_cursor: int, bvid: str, ps: int = 20) -> dict:
+def get_main_page(
+    client: Client, aid: int, next_cursor: int, bvid: str, ps: int = 20
+) -> dict:
     url = (
         "https://api.bilibili.com/x/v2/reply/main"
         f"?type=1&oid={aid}&mode=3&next={next_cursor}&ps={ps}"
@@ -146,7 +164,9 @@ def get_main_page(client: Client, aid: int, next_cursor: int, bvid: str, ps: int
     return client.get_json(url, referer=f"https://www.bilibili.com/video/{bvid}/")
 
 
-def get_sub_page(client: Client, aid: int, root_rpid: int, pn: int, bvid: str, ps: int = 20) -> dict:
+def get_sub_page(
+    client: Client, aid: int, root_rpid: int, pn: int, bvid: str, ps: int = 20
+) -> dict:
     url = (
         "https://api.bilibili.com/x/v2/reply/reply"
         f"?type=1&oid={aid}&root={root_rpid}&ps={ps}&pn={pn}"

--- a/plugins/bbc/skills/bbc-skill/bbc/cli.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/cli.py
@@ -1,0 +1,358 @@
+"""argparse dispatcher for bbc."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from bbc import (
+    __version__,
+    api,
+    cookie,
+    envelope,
+    fetch,
+    fetch_user,
+    progress,
+    schema,
+    summarize,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="bbc",
+        description="Fetch Bilibili video comments for UP主 self-analysis.",
+    )
+    p.add_argument("--version", action="version", version=f"bbc {__version__}")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    # fetch
+    f = sub.add_parser("fetch", help="Fetch all comments for one video (BV or URL)")
+    f.add_argument("target", help="BV number or Bilibili video URL")
+    f.add_argument(
+        "--max", dest="max_top", type=int, default=None, help="Max top-level comments"
+    )
+    f.add_argument(
+        "--since", dest="since", default=None, help="ISO date/time; fetch newer only"
+    )
+    f.add_argument("--output", "-o", default=None, help="Output directory")
+    f.add_argument("--cookie-file", default=None, help="Netscape cookie file")
+    f.add_argument(
+        "--browser",
+        default="auto",
+        choices=["auto", "firefox", "chrome", "edge", "safari"],
+    )
+    f.add_argument("--format", dest="fmt", default=None, choices=["json", "table"])
+    f.add_argument("--dry-run", action="store_true")
+    f.add_argument("--force", action="store_true")
+
+    fu = sub.add_parser("fetch-user", help="Batch fetch all videos of a UP主 by UID")
+    fu.add_argument("uid", type=int)
+    fu.add_argument("--output", "-o", default=None)
+    fu.add_argument("--video-limit", type=int, default=None)
+    fu.add_argument("--max", dest="max_top", type=int, default=None)
+    fu.add_argument("--cookie-file", default=None)
+    fu.add_argument(
+        "--browser",
+        default="auto",
+        choices=["auto", "firefox", "chrome", "edge", "safari"],
+    )
+    fu.add_argument("--format", dest="fmt", default=None, choices=["json", "table"])
+    fu.add_argument("--dry-run", action="store_true")
+
+    # summarize
+    s = sub.add_parser(
+        "summarize", help="Rebuild summary.json from existing comments.jsonl"
+    )
+    s.add_argument("directory")
+    s.add_argument("--format", dest="fmt", default=None, choices=["json", "table"])
+
+    # cookie-check
+    cc = sub.add_parser("cookie-check", help="Validate cookie and print logged-in user")
+    cc.add_argument("--cookie-file", default=None)
+    cc.add_argument(
+        "--browser",
+        default="auto",
+        choices=["auto", "firefox", "chrome", "edge", "safari"],
+    )
+    cc.add_argument("--format", dest="fmt", default=None, choices=["json", "table"])
+
+    # schema
+    sc = sub.add_parser("schema", help="Return JSON schema for a command (or all)")
+    sc.add_argument("cmd", nargs="?", default=None)
+    sc.add_argument("--format", dest="fmt", default=None, choices=["json", "table"])
+
+    return p
+
+
+def _resolve_cookies(args) -> tuple[dict, str]:
+    return cookie.load(
+        cookie_file=getattr(args, "cookie_file", None),
+        browser=getattr(args, "browser", "auto"),
+    )
+
+
+def _cmd_schema(args) -> dict:
+    return envelope.success(
+        schema.describe(args.cmd),
+        request_id=envelope.new_request_id(),
+        elapsed_ms=0,
+    )
+
+
+def _cmd_cookie_check(args) -> dict:
+    req_id = envelope.new_request_id()
+    clock = envelope.Clock()
+    try:
+        cookies, source = _resolve_cookies(args)
+    except cookie.CookieNotFound as e:
+        return envelope.failure(
+            "auth_required",
+            str(e),
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            retryable=True,
+        )
+    client = api.Client(cookies)
+    try:
+        nav = api.get_nav(client)
+    except api.ApiError as e:
+        return envelope.failure(
+            e.code,
+            e.message,
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            retryable=e.retryable,
+        )
+    is_login = bool(nav.get("isLogin"))
+    if not is_login:
+        return envelope.failure(
+            "auth_expired",
+            "cookie does not represent a logged-in session",
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            retryable=True,
+        )
+    return envelope.success(
+        {
+            "mid": nav.get("mid"),
+            "uname": nav.get("uname"),
+            "vip": bool(nav.get("vipStatus") or 0),
+            "level": (nav.get("level_info") or {}).get("current_level"),
+            "source": source,
+            "cookie_names": sorted(cookies.keys()),
+        },
+        request_id=req_id,
+        elapsed_ms=clock.ms(),
+    )
+
+
+def _cmd_fetch(args) -> dict:
+    req_id = envelope.new_request_id()
+    clock = envelope.Clock()
+
+    # dry-run: no cookie load required (just validate target)
+    if args.dry_run:
+        try:
+            data = fetch.run_dry_run(args.target, args.output)
+        except api.ApiError as e:
+            return envelope.failure(
+                e.code,
+                e.message,
+                request_id=req_id,
+                elapsed_ms=clock.ms(),
+                retryable=e.retryable,
+            )
+        return envelope.success(
+            data,
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            extra_top={"dry_run": True},
+        )
+
+    try:
+        cookies, source = _resolve_cookies(args)
+    except cookie.CookieNotFound as e:
+        return envelope.failure(
+            "auth_required",
+            str(e),
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            retryable=True,
+        )
+
+    try:
+        since_ts = fetch.parse_since(args.since)
+    except ValueError as e:
+        return envelope.failure(
+            "validation_error",
+            str(e),
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            field="since",
+        )
+
+    prog = progress.Progress("fetch", req_id)
+    try:
+        data = fetch.run_fetch(
+            target=args.target,
+            cookies=cookies,
+            output=args.output,
+            max_top=args.max_top,
+            since_ts=since_ts,
+            force=args.force,
+            progress=prog,
+        )
+    except api.ApiError as e:
+        return envelope.failure(
+            e.code,
+            e.message,
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            retryable=e.retryable,
+        )
+    except Exception as e:
+        return envelope.failure(
+            "internal_error",
+            f"{type(e).__name__}: {e}",
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+        )
+    data["cookie_source"] = source
+    return envelope.success(data, request_id=req_id, elapsed_ms=clock.ms())
+
+
+def _cmd_fetch_user(args) -> dict:
+    req_id = envelope.new_request_id()
+    clock = envelope.Clock()
+
+    if args.dry_run:
+        data = fetch_user.run_dry_run(args.uid, args.output, args.video_limit)
+        return envelope.success(
+            data,
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            extra_top={"dry_run": True},
+        )
+
+    try:
+        cookies, source = _resolve_cookies(args)
+    except cookie.CookieNotFound as e:
+        return envelope.failure(
+            "auth_required",
+            str(e),
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            retryable=True,
+        )
+
+    prog = progress.Progress("fetch-user", req_id)
+    try:
+        data = fetch_user.run_fetch_user(
+            uid=args.uid,
+            cookies=cookies,
+            output=args.output,
+            video_limit=args.video_limit,
+            max_top=args.max_top,
+            progress=prog,
+        )
+    except api.ApiError as e:
+        return envelope.failure(
+            e.code,
+            e.message,
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            retryable=e.retryable,
+        )
+    except Exception as e:
+        return envelope.failure(
+            "internal_error",
+            f"{type(e).__name__}: {e}",
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+        )
+    data["cookie_source"] = source
+    return envelope.success(data, request_id=req_id, elapsed_ms=clock.ms())
+
+
+def _cmd_summarize(args) -> dict:
+    req_id = envelope.new_request_id()
+    clock = envelope.Clock()
+    d = Path(args.directory).expanduser().resolve()
+    jsonl = d / "comments.jsonl"
+    if not jsonl.exists():
+        return envelope.failure(
+            "validation_error",
+            f"no comments.jsonl in {d}",
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            field="directory",
+        )
+    raw_view = d / "raw" / "view.json"
+    raw_tags = d / "raw" / "tags.json"
+    try:
+        view = (
+            json.loads(raw_view.read_text(encoding="utf-8"))
+            if raw_view.exists()
+            else {}
+        )
+        tags = (
+            json.loads(raw_tags.read_text(encoding="utf-8"))
+            if raw_tags.exists()
+            else []
+        )
+    except (OSError, json.JSONDecodeError) as e:
+        return envelope.failure(
+            "validation_error",
+            f"malformed raw metadata in {d}/raw: {e}",
+            request_id=req_id,
+            elapsed_ms=clock.ms(),
+            field="directory",
+        )
+    video_meta = summarize.video_meta_from_view(view, tags)
+    summary = summarize.build_summary(
+        jsonl_path=jsonl,
+        video_meta=video_meta,
+        fetch_range={"mode": "resumed", "max": None, "since": None, "resumed": True},
+        declared_all_count=None,
+    )
+    out = d / "summary.json"
+    out.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    return envelope.success(
+        {"summary_path": str(out), "counts": summary["counts"]},
+        request_id=req_id,
+        elapsed_ms=clock.ms(),
+    )
+
+
+DISPATCH = {
+    "schema": _cmd_schema,
+    "cookie-check": _cmd_cookie_check,
+    "fetch": _cmd_fetch,
+    "fetch-user": _cmd_fetch_user,
+    "summarize": _cmd_summarize,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    handler = DISPATCH.get(args.command)
+    if handler is None:
+        env = envelope.failure(
+            "validation_error",
+            f"unknown command: {args.command}",
+            request_id=envelope.new_request_id(),
+            elapsed_ms=0,
+        )
+    else:
+        env = handler(args)
+
+    fmt = envelope.effective_format(getattr(args, "fmt", None))
+    envelope.emit(env, fmt)
+    return envelope.exit_for(env)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/bbc/skills/bbc-skill/bbc/cookie/__init__.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/cookie/__init__.py
@@ -1,0 +1,125 @@
+"""Cookie auto-detect orchestrator.
+
+Priority:
+1. Explicit cookie file (arg or $BBC_COOKIE_FILE)
+2. $BBC_SESSDATA env (direct value)
+3. Cached config ~/.config/bbc-skill/cookie.json
+4. Auto-detect browsers (by OS)
+
+Returns a dict of {name: value} or raises CookieNotFound.
+"""
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from . import chrome_macos, firefox, netscape
+
+
+class CookieNotFound(Exception):
+    pass
+
+
+CONFIG_PATH = Path.home() / ".config/bbc-skill/cookie.json"
+
+
+def _from_env_sessdata() -> dict[str, str] | None:
+    val = os.environ.get("BBC_SESSDATA", "").strip()
+    if val:
+        return {"SESSDATA": val}
+    return None
+
+
+def _from_config_file() -> dict[str, str] | None:
+    if not CONFIG_PATH.exists():
+        return None
+    try:
+        data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and data.get("SESSDATA"):
+            return {k: v for k, v in data.items() if isinstance(v, str)}
+    except (OSError, json.JSONDecodeError):
+        pass
+    return None
+
+
+def _auto_detect(browser_hint: str = "auto") -> tuple[dict[str, str] | None, str | None]:
+    """Returns (cookies, source_label)."""
+    candidates: list[tuple[str, Callable[[], dict[str, str] | None]]] = []
+
+    if browser_hint in ("auto", "firefox"):
+        candidates.append(("firefox", firefox.extract))
+    if browser_hint in ("auto", "chrome"):
+        if sys.platform == "darwin":
+            candidates.append(("chrome (macOS)", lambda: chrome_macos.extract("chrome")))
+    if browser_hint in ("auto", "edge"):
+        if sys.platform == "darwin":
+            candidates.append(("edge (macOS)", lambda: chrome_macos.extract("edge")))
+
+    for label, fn in candidates:
+        try:
+            cookies = fn()
+        except Exception:
+            cookies = None
+        if cookies and cookies.get("SESSDATA"):
+            return cookies, label
+    return None, None
+
+
+def load(
+    *,
+    cookie_file: str | None = None,
+    browser: str = "auto",
+) -> tuple[dict[str, str], str]:
+    """Load cookies. Returns (cookies, source).
+
+    Raises CookieNotFound if none found.
+    """
+    # 1. Explicit cookie file
+    if cookie_file:
+        path = Path(cookie_file).expanduser()
+        if not path.exists():
+            raise CookieNotFound(f"cookie file not found: {path}")
+        cookies = netscape.parse(path)
+        if not cookies.get("SESSDATA"):
+            raise CookieNotFound(f"no SESSDATA in cookie file: {path}")
+        return cookies, f"file:{path}"
+
+    # 2. $BBC_COOKIE_FILE
+    env_file = os.environ.get("BBC_COOKIE_FILE", "").strip()
+    if env_file:
+        path = Path(env_file).expanduser()
+        if path.exists():
+            cookies = netscape.parse(path)
+            if cookies.get("SESSDATA"):
+                return cookies, f"env:BBC_COOKIE_FILE={path}"
+
+    # 3. $BBC_SESSDATA direct
+    env_cookies = _from_env_sessdata()
+    if env_cookies:
+        return env_cookies, "env:BBC_SESSDATA"
+
+    # 4. Cached config file
+    cached = _from_config_file()
+    if cached:
+        return cached, f"config:{CONFIG_PATH}"
+
+    # 5. Auto-detect browser
+    cookies, source = _auto_detect(browser)
+    if cookies:
+        return cookies, f"browser:{source}"
+
+    raise CookieNotFound(
+        "No cookie found. Provide --cookie-file, set $BBC_SESSDATA, "
+        "or log into bilibili.com in Chrome/Firefox/Edge (supported) and retry."
+    )
+
+
+def save_to_config(cookies: dict[str, str]) -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(cookies, ensure_ascii=False), encoding="utf-8")
+    try:
+        os.chmod(CONFIG_PATH, 0o600)
+    except OSError:
+        pass

--- a/plugins/bbc/skills/bbc-skill/bbc/cookie/__init__.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/cookie/__init__.py
@@ -44,7 +44,9 @@ def _from_config_file() -> dict[str, str] | None:
     return None
 
 
-def _auto_detect(browser_hint: str = "auto") -> tuple[dict[str, str] | None, str | None]:
+def _auto_detect(
+    browser_hint: str = "auto",
+) -> tuple[dict[str, str] | None, str | None]:
     """Returns (cookies, source_label)."""
     candidates: list[tuple[str, Callable[[], dict[str, str] | None]]] = []
 
@@ -52,7 +54,9 @@ def _auto_detect(browser_hint: str = "auto") -> tuple[dict[str, str] | None, str
         candidates.append(("firefox", firefox.extract))
     if browser_hint in ("auto", "chrome"):
         if sys.platform == "darwin":
-            candidates.append(("chrome (macOS)", lambda: chrome_macos.extract("chrome")))
+            candidates.append(
+                ("chrome (macOS)", lambda: chrome_macos.extract("chrome"))
+            )
     if browser_hint in ("auto", "edge"):
         if sys.platform == "darwin":
             candidates.append(("edge (macOS)", lambda: chrome_macos.extract("edge")))

--- a/plugins/bbc/skills/bbc-skill/bbc/cookie/chrome_macos.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/cookie/chrome_macos.py
@@ -1,0 +1,159 @@
+"""Chrome / Edge cookie extraction on macOS.
+
+Uses:
+- sqlite3 (stdlib) to read the Cookies DB
+- `security find-generic-password` to fetch the AES password from Keychain
+- hashlib.pbkdf2_hmac (stdlib) to derive the AES-128 key
+- `openssl enc -aes-128-cbc` (system binary) to decrypt cookie values
+
+Zero pip install. macOS-only.
+"""
+
+import binascii
+import glob
+import hashlib
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SALT = b"saltysalt"
+ITERATIONS = 1003
+KEY_LEN = 16
+IV = b" " * 16  # 16 spaces
+
+CHROME_SERVICES = {
+    "chrome": ("Chrome", "Chrome"),
+    "edge": ("Microsoft Edge", "Microsoft Edge"),
+    "chromium": ("Chromium", "Chromium"),
+}
+
+
+def _profile_paths(browser: str) -> list[Path]:
+    home = Path.home()
+    if browser == "chrome":
+        base = home / "Library/Application Support/Google/Chrome"
+    elif browser == "edge":
+        base = home / "Library/Application Support/Microsoft Edge"
+    elif browser == "chromium":
+        base = home / "Library/Application Support/Chromium"
+    else:
+        return []
+    if not base.exists():
+        return []
+    results = []
+    for prof in ["Default"] + sorted(glob.glob(str(base / "Profile *"))):
+        p = base / prof if isinstance(prof, str) and "/" not in prof else Path(prof)
+        # Chrome >= ~96 moved Cookies under Network/
+        for candidate in [p / "Network/Cookies", p / "Cookies"]:
+            if candidate.exists():
+                results.append(candidate)
+                break
+    return results
+
+
+def _fetch_key(browser: str) -> bytes | None:
+    if sys.platform != "darwin":
+        return None
+    if browser not in CHROME_SERVICES:
+        return None
+    svc_name, account = CHROME_SERVICES[browser]
+    try:
+        out = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-w",
+                "-s",
+                f"{svc_name} Safe Storage",
+                "-a",
+                account,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode != 0:
+            return None
+        password = out.stdout.strip().encode()
+        if not password:
+            return None
+        return hashlib.pbkdf2_hmac("sha1", password, SALT, ITERATIONS, KEY_LEN)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _decrypt_value(encrypted: bytes, key: bytes) -> str | None:
+    if not encrypted:
+        return None
+    # Chrome prefixes with version tag: v10 or v11
+    if encrypted[:3] in (b"v10", b"v11"):
+        body = encrypted[3:]
+    else:
+        # Possibly legacy plaintext
+        try:
+            return encrypted.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    try:
+        proc = subprocess.run(
+            [
+                "openssl",
+                "enc",
+                "-d",
+                "-aes-128-cbc",
+                "-K",
+                binascii.hexlify(key).decode(),
+                "-iv",
+                binascii.hexlify(IV).decode(),
+            ],
+            input=body,
+            capture_output=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            return None
+        plain = proc.stdout
+        # PKCS#7 padding is auto-handled by openssl; trailing spaces may still exist
+        return plain.decode("utf-8", errors="ignore").rstrip("\x00 ")
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def extract(browser: str = "chrome", domain_filter: str = "bilibili.com") -> dict[str, str] | None:
+    key = _fetch_key(browser)
+    if not key:
+        return None
+
+    for db_path in _profile_paths(browser):
+        try:
+            with tempfile.NamedTemporaryFile(prefix="bbc-chrome-", suffix=".db", delete=False) as tf:
+                tmp = Path(tf.name)
+            shutil.copy2(db_path, tmp)
+            try:
+                conn = sqlite3.connect(f"file:{tmp}?mode=ro", uri=True)
+                cur = conn.execute(
+                    "SELECT name, value, encrypted_value FROM cookies WHERE host_key LIKE ?",
+                    (f"%{domain_filter}%",),
+                )
+                cookies: dict[str, str] = {}
+                for name, value, enc in cur.fetchall():
+                    if value:
+                        cookies[name] = value
+                    elif enc:
+                        dec = _decrypt_value(bytes(enc), key)
+                        if dec is not None:
+                            cookies[name] = dec
+                conn.close()
+            finally:
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+            if cookies.get("SESSDATA"):
+                return cookies
+        except sqlite3.DatabaseError:
+            continue
+    return None

--- a/plugins/bbc/skills/bbc-skill/bbc/cookie/chrome_macos.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/cookie/chrome_macos.py
@@ -122,14 +122,18 @@ def _decrypt_value(encrypted: bytes, key: bytes) -> str | None:
         return None
 
 
-def extract(browser: str = "chrome", domain_filter: str = "bilibili.com") -> dict[str, str] | None:
+def extract(
+    browser: str = "chrome", domain_filter: str = "bilibili.com"
+) -> dict[str, str] | None:
     key = _fetch_key(browser)
     if not key:
         return None
 
     for db_path in _profile_paths(browser):
         try:
-            with tempfile.NamedTemporaryFile(prefix="bbc-chrome-", suffix=".db", delete=False) as tf:
+            with tempfile.NamedTemporaryFile(
+                prefix="bbc-chrome-", suffix=".db", delete=False
+            ) as tf:
                 tmp = Path(tf.name)
             shutil.copy2(db_path, tmp)
             try:

--- a/plugins/bbc/skills/bbc-skill/bbc/cookie/firefox.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/cookie/firefox.py
@@ -1,0 +1,63 @@
+"""Firefox cookie extraction — stdlib sqlite3, no encryption.
+
+Works on macOS, Linux, Windows. Copies DB to a temp file since Firefox may
+hold a WAL lock.
+"""
+
+import glob
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _profile_dirs() -> list[Path]:
+    home = Path.home()
+    patterns: list[str] = []
+    if sys.platform == "darwin":
+        patterns.append(str(home / "Library/Application Support/Firefox/Profiles/*"))
+    elif sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA", "")
+        if appdata:
+            patterns.append(os.path.join(appdata, "Mozilla/Firefox/Profiles/*"))
+    else:
+        patterns.append(str(home / ".mozilla/firefox/*"))
+
+    found = []
+    for pat in patterns:
+        for p in glob.glob(pat):
+            path = Path(p)
+            if (path / "cookies.sqlite").exists():
+                found.append(path)
+    return found
+
+
+def extract(domain_filter: str = "bilibili.com") -> dict[str, str] | None:
+    for profile in _profile_dirs():
+        db = profile / "cookies.sqlite"
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix="bbc-ff-", suffix=".sqlite", delete=False
+            ) as tf:
+                tmp_path = Path(tf.name)
+            shutil.copy2(db, tmp_path)
+            try:
+                conn = sqlite3.connect(f"file:{tmp_path}?mode=ro", uri=True)
+                cur = conn.execute(
+                    "SELECT name, value FROM moz_cookies WHERE host LIKE ?",
+                    (f"%{domain_filter}%",),
+                )
+                cookies = {name: value for name, value in cur.fetchall()}
+                conn.close()
+            finally:
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+            if cookies.get("SESSDATA"):
+                return cookies
+        except sqlite3.DatabaseError:
+            continue
+    return None

--- a/plugins/bbc/skills/bbc-skill/bbc/cookie/netscape.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/cookie/netscape.py
@@ -1,0 +1,19 @@
+"""Parse Netscape-format cookie files (e.g. exported by browser extensions)."""
+
+from pathlib import Path
+
+
+def parse(path: Path, domain_filter: str = "bilibili.com") -> dict[str, str]:
+    cookies: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 7:
+            continue
+        domain = parts[0]
+        if domain_filter not in domain:
+            continue
+        name, value = parts[5], parts[6]
+        cookies[name] = value
+    return cookies

--- a/plugins/bbc/skills/bbc-skill/bbc/envelope.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/envelope.py
@@ -136,9 +136,7 @@ def _print_table_success(env: dict) -> None:
                 sys.stdout.write(f"{k}:\n")
                 sys.stdout.write(
                     "  "
-                    + json.dumps(v, ensure_ascii=False, indent=2).replace(
-                        "\n", "\n  "
-                    )
+                    + json.dumps(v, ensure_ascii=False, indent=2).replace("\n", "\n  ")
                     + "\n"
                 )
             else:

--- a/plugins/bbc/skills/bbc-skill/bbc/envelope.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/envelope.py
@@ -1,0 +1,169 @@
+"""JSON envelope, exit codes, TTY detection."""
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+
+from bbc import SCHEMA_VERSION
+
+# Exit codes — see references/agent-contract.md
+EXIT_OK = 0
+EXIT_RUNTIME = 1
+EXIT_AUTH = 2
+EXIT_VALIDATION = 3
+EXIT_NETWORK = 4
+
+ERROR_CODE_TO_EXIT = {
+    "validation_error": EXIT_VALIDATION,
+    "auth_required": EXIT_AUTH,
+    "auth_expired": EXIT_AUTH,
+    "not_found": EXIT_RUNTIME,
+    "rate_limited": EXIT_RUNTIME,
+    "api_error": EXIT_RUNTIME,
+    "network_error": EXIT_NETWORK,
+    "internal_error": EXIT_RUNTIME,
+}
+
+
+def stdout_is_tty() -> bool:
+    try:
+        return sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def effective_format(explicit: str | None) -> str:
+    if explicit in ("json", "table"):
+        return explicit
+    return "table" if stdout_is_tty() else "json"
+
+
+def new_request_id() -> str:
+    return "req_" + uuid.uuid4().hex[:12]
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.start = time.monotonic()
+
+    def ms(self) -> int:
+        return int((time.monotonic() - self.start) * 1000)
+
+
+def success(
+    data: Any,
+    *,
+    request_id: str,
+    elapsed_ms: int,
+    extra_meta: dict | None = None,
+    extra_top: dict | None = None,
+) -> dict:
+    env = {
+        "ok": True,
+        "data": data,
+        "meta": {
+            "request_id": request_id,
+            "latency_ms": elapsed_ms,
+            "schema_version": SCHEMA_VERSION,
+            **(extra_meta or {}),
+        },
+    }
+    if extra_top:
+        env.update(extra_top)
+    return env
+
+
+def failure(
+    code: str,
+    message: str,
+    *,
+    request_id: str,
+    elapsed_ms: int,
+    retryable: bool = False,
+    field: str | None = None,
+    extra: dict | None = None,
+) -> dict:
+    err: dict = {"code": code, "message": message, "retryable": retryable}
+    if field:
+        err["field"] = field
+    if code == "auth_expired":
+        err["retry_after_auth"] = True
+    if extra:
+        err.update(extra)
+    return {
+        "ok": False,
+        "error": err,
+        "meta": {
+            "request_id": request_id,
+            "latency_ms": elapsed_ms,
+            "schema_version": SCHEMA_VERSION,
+        },
+    }
+
+
+def emit_json(env: dict) -> None:
+    """Emit envelope to stdout as JSON (single line + trailing newline)."""
+    json.dump(env, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def emit_table(env: dict) -> None:
+    """Human-readable rendering (very simple)."""
+    if env.get("ok") == True or env.get("ok") == "partial":
+        _print_table_success(env)
+    else:
+        err = env.get("error", {})
+        sys.stdout.write(
+            f"\x1b[31mERROR\x1b[0m [{err.get('code')}] {err.get('message')}\n"
+            if _colors_ok()
+            else f"ERROR [{err.get('code')}] {err.get('message')}\n"
+        )
+        if err.get("retryable"):
+            sys.stdout.write("  (retryable)\n")
+    sys.stdout.flush()
+
+
+def _print_table_success(env: dict) -> None:
+    data = env.get("data")
+    if isinstance(data, dict):
+        # Flatten one level
+        for k, v in data.items():
+            if isinstance(v, (dict, list)):
+                sys.stdout.write(f"{k}:\n")
+                sys.stdout.write(
+                    "  "
+                    + json.dumps(v, ensure_ascii=False, indent=2).replace(
+                        "\n", "\n  "
+                    )
+                    + "\n"
+                )
+            else:
+                sys.stdout.write(f"{k}: {v}\n")
+    else:
+        sys.stdout.write(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+
+
+def _colors_ok() -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    return stdout_is_tty()
+
+
+def emit(env: dict, fmt: str) -> None:
+    if fmt == "table":
+        emit_table(env)
+    else:
+        emit_json(env)
+
+
+def exit_for(env: dict) -> int:
+    if env.get("ok") == True:
+        return EXIT_OK
+    if env.get("ok") == "partial":
+        return EXIT_OK
+    code = env.get("error", {}).get("code", "internal_error")
+    return ERROR_CODE_TO_EXIT.get(code, EXIT_RUNTIME)

--- a/plugins/bbc/skills/bbc-skill/bbc/fetch.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/fetch.py
@@ -1,0 +1,379 @@
+"""bbc fetch — main comment fetcher."""
+
+import contextlib
+import json
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from bbc import api, flatten, summarize
+from bbc.progress import Progress
+
+BV_RE = re.compile(r"BV[A-Za-z0-9]{10}")
+URL_BV_RE = re.compile(r"/video/(BV[A-Za-z0-9]{10})", re.IGNORECASE)
+
+
+def parse_target(target: str) -> str | None:
+    """Extract a BV number from a BV string or full URL."""
+    if not target:
+        return None
+    target = target.strip()
+    m = URL_BV_RE.search(target)
+    if m:
+        return m.group(1)
+    if BV_RE.fullmatch(target):
+        return target
+    m = BV_RE.search(target)
+    if m:
+        return m.group(0)
+    return None
+
+
+def parse_since(value: str | None) -> int | None:
+    if not value:
+        return None
+    value = value.strip()
+    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(value, fmt).replace(tzinfo=timezone.utc)
+            return int(dt.timestamp())
+        except ValueError:
+            continue
+    if value.isdigit():
+        return int(value)
+    raise ValueError(f"unrecognized --since value: {value}")
+
+
+def default_output_dir(bvid: str) -> Path:
+    return (Path.cwd() / "bilibili-comments" / bvid).resolve()
+
+
+class FetchState:
+    """Tracks resume state across runs (.bbc-state.json)."""
+
+    def __init__(self, out_dir: Path, bvid: str | None = None):
+        self.path = out_dir / ".bbc-state.json"
+        self.data: dict = {
+            "bvid": None,  # ownership: bound explicitly by run_fetch after validation; None = unknown (legacy/new state)
+            "next_cursor": 0,
+            "top_pages_done": 0,
+            "top_done": False,
+            "subs_done": [],  # list of rpids completed
+            "latest_ctime": 0,
+            "declared_all_count": None,
+            "version": 1,
+        }
+        if self.path.exists():
+            with contextlib.suppress(OSError, json.JSONDecodeError):
+                self.data.update(json.loads(self.path.read_text(encoding="utf-8")))
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            json.dumps(self.data, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+
+def _invalidate(out_dir: Path, jsonl_path: Path) -> None:
+    """Remove prior output + resume state so the next fetch starts from scratch."""
+    for path in (jsonl_path, out_dir / ".bbc-state.json"):
+        if path.exists():
+            path.unlink()
+
+
+def _as_int(value: Any, what: str) -> int:
+    """Coerce a Bilibili API / JSONL field to int; envelope-safe error on malformed data."""
+    try:
+        return int(value)
+    except (TypeError, ValueError) as e:
+        raise api.ApiError("validation_error", f"malformed {what}: {value!r}") from e
+
+
+def _require_bvid(target: str) -> str:
+    """Extract a BV id or raise the validation-error envelope ApiError."""
+    bvid = parse_target(target)
+    if not bvid:
+        raise api.ApiError(
+            "validation_error", f"cannot extract BV number from: {target!r}"
+        )
+    return bvid
+
+
+def run_fetch(
+    *,
+    target: str,
+    cookies: dict,
+    output: str | None,
+    max_top: int | None,
+    since_ts: int | None,
+    force: bool,
+    progress: Progress,
+) -> dict[str, Any]:
+    bvid = _require_bvid(target)
+
+    out_dir = (
+        Path(output).expanduser().resolve() if output else default_output_dir(bvid)
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "raw").mkdir(exist_ok=True)
+
+    jsonl_path = out_dir / "comments.jsonl"
+    summary_path = out_dir / "summary.json"
+
+    state = FetchState(out_dir)
+
+    # --force, or state that belongs to another video (or ownership unverifiable)
+    # -> old data invalidated, refetch from scratch
+    if force or state.data.get("bvid") != bvid:
+        _invalidate(out_dir, jsonl_path)
+        state = FetchState(out_dir)
+    state.data["bvid"] = bvid
+
+    progress.start(bvid=bvid, output=str(out_dir))
+
+    client = api.Client(
+        cookies, min_interval_sec=1.0, referer=f"https://www.bilibili.com/video/{bvid}/"
+    )
+
+    # 1. Video meta
+    view = api.bv_to_view(client, bvid)
+    aid = _as_int(view["aid"], "aid")
+    owner_mid = _as_int((view.get("owner") or {}).get("mid") or 0, "owner.mid")
+    title = view.get("title") or ""
+    progress.progress(phase="meta", title=title, aid=aid)
+    (out_dir / "raw" / "view.json").write_text(
+        json.dumps(view, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    tags = api.get_tags(client, bvid)
+    (out_dir / "raw" / "tags.json").write_text(
+        json.dumps(tags, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # Open JSONL append mode; if resuming we trust existing lines
+    appended_ids: set[int] = set()
+    if jsonl_path.exists() and not force:
+        with jsonl_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    rpid = json.loads(line).get("rpid")
+                    if rpid:
+                        appended_ids.add(int(rpid))
+                except json.JSONDecodeError:
+                    continue
+
+    jsonl_file = jsonl_path.open("a", encoding="utf-8")
+
+    def write_row(row: dict) -> None:
+        rpid = row.get("rpid")
+        if not rpid or rpid in appended_ids:
+            return
+        appended_ids.add(rpid)
+        jsonl_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    # 2. Top-level loop (+ first-page pinned)
+    top_level_replies: list[dict] = []
+    pinned_count = 0
+    next_cursor = 0 if force else state.data.get("next_cursor", 0)
+    page = 0 if force else state.data.get("top_pages_done", 0)
+    declared_all = state.data.get("declared_all_count")
+
+    if not state.data.get("top_done"):
+        while True:
+            page += 1
+            data = api.get_main_page(client, aid, next_cursor, bvid)
+            d = data.get("data") or {}
+            cur = d.get("cursor") or {}
+            if declared_all is None:
+                declared_all = cur.get("all_count")
+                state.data["declared_all_count"] = declared_all
+
+            replies = d.get("replies") or []
+
+            # pinned only on first page
+            if page == 1:
+                for pr in d.get("top_replies") or []:
+                    row = flatten.flatten_reply(
+                        pr, bvid=bvid, owner_mid=owner_mid, top_type=2
+                    )
+                    if row.get("mid") == owner_mid:
+                        row["top_type"] = 1  # UP置顶
+                    write_row(row)
+                    top_level_replies.append(pr)
+                    pinned_count += 1
+                upper = (d.get("upper") or {}).get("top") or None
+                if isinstance(upper, dict):
+                    row = flatten.flatten_reply(
+                        upper, bvid=bvid, owner_mid=owner_mid, top_type=1
+                    )
+                    write_row(row)
+                    top_level_replies.append(upper)
+                    pinned_count += 1
+
+            # save raw
+            (out_dir / "raw" / f"main-page-{page:03d}.json").write_text(
+                json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+
+            progress.progress(
+                phase="top_level",
+                page=page,
+                done=len(replies),
+                cumulative=len(appended_ids),
+                declared_total=declared_all,
+            )
+
+            should_stop = False
+            for r in replies:
+                ctime = _as_int(r.get("ctime") or 0, "ctime")
+                if since_ts and ctime < since_ts:
+                    should_stop = True
+                    continue
+                row = flatten.flatten_reply(
+                    r, bvid=bvid, owner_mid=owner_mid, top_type=0
+                )
+                write_row(row)
+                top_level_replies.append(r)
+                if ctime > state.data["latest_ctime"]:
+                    state.data["latest_ctime"] = ctime
+
+            if (
+                max_top
+                and len([r for r in top_level_replies if r.get("parent", 0) == 0])
+                >= max_top
+            ):
+                should_stop = True
+
+            if cur.get("is_end") or not replies or should_stop:
+                break
+            next_cursor = cur.get("next")
+            if not next_cursor:
+                break
+
+            state.data["next_cursor"] = next_cursor
+            state.data["top_pages_done"] = page
+            state.save()
+
+        state.data["top_done"] = True
+        state.data["top_pages_done"] = page
+        state.save()
+
+    # 3. Nested replies — iterate top-level entries with rcount > 0
+    done_subs = set(state.data.get("subs_done") or [])
+    subs_count = 0
+    subs_threads = 0
+
+    # Flush appended top-level rows so the re-read sees everything.
+    jsonl_file.flush()
+
+    thread_candidates = []
+    with jsonl_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                row.get("parent", 0) == 0
+                and _as_int(row.get("rcount") or 0, "rcount") > 0
+            ):
+                thread_candidates.append(
+                    (_as_int(row["rpid"], "rpid"), _as_int(row["rcount"], "rcount"))
+                )
+
+    for rpid, rcount in thread_candidates:
+        if rpid in done_subs:
+            continue
+        subs_threads += 1
+        pn = 1
+        while True:
+            sd = api.get_sub_page(client, aid, rpid, pn, bvid)
+            subs = (sd.get("data") or {}).get("replies") or []
+            (out_dir / "raw" / f"reply-{rpid}-p{pn:03d}.json").write_text(
+                json.dumps(sd, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            for sr in subs:
+                if since_ts and _as_int(sr.get("ctime") or 0, "ctime") < since_ts:
+                    continue
+                row = flatten.flatten_reply(
+                    sr, bvid=bvid, owner_mid=owner_mid, top_type=0
+                )
+                write_row(row)
+                subs_count += 1
+            progress.progress(
+                phase="nested",
+                root_rpid=rpid,
+                page=pn,
+                got=len(subs),
+                cumulative_subs=subs_count,
+            )
+            if len(subs) < 20:
+                break
+            pn += 1
+            # shorter throttle for sub pages
+            time.sleep(0.5)
+        done_subs.add(rpid)
+        state.data["subs_done"] = sorted(done_subs)
+        state.save()
+
+    jsonl_file.close()
+
+    # 4. Summary
+    video_meta = summarize.video_meta_from_view(view, tags)
+    fetch_range = {
+        "mode": "full" if not (max_top or since_ts) else "partial",
+        "max": max_top,
+        "since": since_ts,
+        "resumed": False,
+    }
+    summary = summarize.build_summary(
+        jsonl_path=jsonl_path,
+        video_meta=video_meta,
+        fetch_range=fetch_range,
+        declared_all_count=declared_all,
+    )
+    summary_path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    progress.complete(counts=summary["counts"])
+
+    return {
+        "bvid": bvid,
+        "aid": aid,
+        "title": title,
+        "output_dir": str(out_dir),
+        "files": {
+            "comments": str(jsonl_path.relative_to(out_dir.parent))
+            if out_dir.parent in jsonl_path.parents
+            else "comments.jsonl",
+            "summary": "summary.json",
+            "raw_dir": "raw/",
+        },
+        "counts": summary["counts"],
+        "completeness": summary["counts"].get("completeness"),
+    }
+
+
+def run_dry_run(target: str, output: str | None) -> dict[str, Any]:
+    bvid = _require_bvid(target)
+    out_dir = (
+        Path(output).expanduser().resolve() if output else default_output_dir(bvid)
+    )
+    return {
+        "dry_run": True,
+        "would": {
+            "bvid": bvid,
+            "output_dir": str(out_dir),
+            "endpoints": [
+                "GET /x/web-interface/view",
+                "GET /x/tag/archive/tags",
+                "GET /x/v2/reply/main (paginated, ~20 per page)",
+                "GET /x/v2/reply/reply (per thread with rcount>0, paginated)",
+            ],
+            "rate_limit": "1.0s between top-level requests, 0.5s between sub-replies",
+            "note": "Exact request count depends on total comments and nested threads. Use 'bbc fetch <BV>' to execute.",
+        },
+    }

--- a/plugins/bbc/skills/bbc-skill/bbc/fetch_user.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/fetch_user.py
@@ -1,0 +1,244 @@
+"""bbc fetch-user — sequentially fetch comments for all videos of a UP主.
+
+Strict sequential: one video at a time. Never parallel. Failures on an
+individual video are recorded to channel-summary.json.errors and the next
+video continues.
+"""
+
+import json
+import random
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from bbc import api, fetch, wbi
+from bbc.progress import Progress
+
+INTER_VIDEO_SLEEP_MIN = 5.0
+INTER_VIDEO_SLEEP_MAX = 10.0
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def default_output_dir(uid: int) -> Path:
+    return (Path.cwd() / "bilibili-comments" / f"user-{uid}").resolve()
+
+
+def _list_all_videos(client: api.Client, uid: int, img_key: str, sub_key: str, *, limit: int | None) -> list[dict]:
+    """Paginate through all user videos. Returns list of dicts with bvid/title/play/comment/created."""
+    videos: list[dict] = []
+    pn = 1
+    ps = 30
+    while True:
+        data = api.list_user_videos(client, uid, img_key=img_key, sub_key=sub_key, pn=pn, ps=ps)
+        vlist = (data.get("data", {}).get("list", {}) or {}).get("vlist") or []
+        page_info = (data.get("data", {}).get("page", {})) or {}
+        for v in vlist:
+            videos.append(
+                {
+                    "bvid": v.get("bvid"),
+                    "aid": v.get("aid"),
+                    "title": v.get("title"),
+                    "play": v.get("play"),
+                    "comment": v.get("comment"),
+                    "created": v.get("created"),
+                    "description": v.get("description"),
+                    "pic": v.get("pic"),
+                }
+            )
+            if limit and len(videos) >= limit:
+                return videos
+        total = int(page_info.get("count") or 0)
+        if not vlist or len(videos) >= total:
+            break
+        pn += 1
+        time.sleep(0.5)
+    return videos
+
+
+def _load_channel_state(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {"completed_bvids": [], "errors": []}
+
+
+def run_fetch_user(
+    *,
+    uid: int,
+    cookies: dict,
+    output: str | None,
+    video_limit: int | None,
+    max_top: int | None,
+    progress: Progress,
+    inter_video_sleep_range: tuple[float, float] = (INTER_VIDEO_SLEEP_MIN, INTER_VIDEO_SLEEP_MAX),
+) -> dict[str, Any]:
+    out_dir = Path(output).expanduser().resolve() if output else default_output_dir(uid)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    state_path = out_dir / ".bbc-channel-state.json"
+    state = _load_channel_state(state_path)
+    completed = set(state.get("completed_bvids") or [])
+
+    client = api.Client(cookies, min_interval_sec=1.0)
+
+    progress.start(uid=uid, output=str(out_dir))
+
+    # 1. Get owner info + WBI keys
+    nav = api.get_nav(client)
+    img_key, sub_key = wbi.keys_from_nav(nav)
+    progress.progress(phase="nav", img_key_len=len(img_key))
+
+    # 2. List videos
+    progress.progress(phase="list_videos", message="fetching video list…")
+    videos = _list_all_videos(client, uid, img_key, sub_key, limit=video_limit)
+    progress.progress(phase="list_videos", total_videos=len(videos))
+
+    (out_dir / "videos.json").write_text(
+        json.dumps(videos, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # 3. Sequentially fetch each video (NEVER parallel)
+    per_video_results: list[dict] = []
+    errors: list[dict] = list(state.get("errors") or [])
+
+    for idx, v in enumerate(videos, start=1):
+        bvid = v.get("bvid")
+        if not bvid:
+            continue
+        if bvid in completed:
+            progress.progress(phase="skip_video", idx=idx, total=len(videos), bvid=bvid, reason="already_done")
+            continue
+
+        video_out = out_dir / bvid
+        progress.progress(
+            phase="video_start", idx=idx, total=len(videos),
+            bvid=bvid, title=v.get("title"), declared_comments=v.get("comment"),
+        )
+
+        sub_progress = Progress("fetch-user.video", progress.request_id, enabled=progress.enabled)
+        try:
+            result = fetch.run_fetch(
+                target=bvid,
+                cookies=cookies,
+                output=str(video_out),
+                max_top=max_top,
+                since_ts=None,
+                force=False,
+                progress=sub_progress,
+            )
+            per_video_results.append(
+                {
+                    "bvid": bvid,
+                    "title": v.get("title"),
+                    "output_dir": str(video_out),
+                    "counts": result.get("counts"),
+                    "completeness": result.get("completeness"),
+                }
+            )
+            completed.add(bvid)
+            progress.progress(
+                phase="video_done", idx=idx, total=len(videos),
+                bvid=bvid, counts=result.get("counts"),
+            )
+        except api.ApiError as e:
+            err_rec = {
+                "bvid": bvid,
+                "title": v.get("title"),
+                "code": e.code,
+                "message": e.message,
+                "retryable": e.retryable,
+                "at": _iso_now(),
+            }
+            errors.append(err_rec)
+            progress.warn(f"video {bvid} failed", **err_rec)
+        except Exception as e:
+            err_rec = {
+                "bvid": bvid,
+                "title": v.get("title"),
+                "code": "internal_error",
+                "message": f"{type(e).__name__}: {e}",
+                "retryable": False,
+                "at": _iso_now(),
+            }
+            errors.append(err_rec)
+            progress.warn(f"video {bvid} crashed", **err_rec)
+
+        # Persist state after every video (resume-safe even if killed)
+        state_path.write_text(
+            json.dumps(
+                {"completed_bvids": sorted(completed), "errors": errors},
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        # Inter-video cooldown — only if not last; randomised to mimic human
+        # cadence and reduce the chance of B站 risk-control banning the session.
+        if idx < len(videos):
+            sleep_for = random.uniform(*inter_video_sleep_range)
+            progress.progress(phase="cooldown", seconds=round(sleep_for, 2))
+            time.sleep(sleep_for)
+
+    # 4. Channel-level summary
+    summary = {
+        "schema_version": "1.0.0",
+        "generated_at": _iso_now(),
+        "uid": uid,
+        "video_count_total": len(videos),
+        "video_count_fetched": len(per_video_results),
+        "video_count_skipped": len(videos) - len(per_video_results) - len(errors),
+        "video_count_failed": len(errors),
+        "videos": per_video_results,
+        "errors": errors,
+    }
+    summary_path = out_dir / "channel-summary.json"
+    summary_path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    progress.complete(
+        uid=uid, total=len(videos), fetched=len(per_video_results), failed=len(errors)
+    )
+
+    return {
+        "uid": uid,
+        "output_dir": str(out_dir),
+        "video_count_total": len(videos),
+        "video_count_fetched": len(per_video_results),
+        "video_count_failed": len(errors),
+        "files": {
+            "videos": "videos.json",
+            "channel_summary": "channel-summary.json",
+        },
+    }
+
+
+def run_dry_run(uid: int, output: str | None, video_limit: int | None) -> dict[str, Any]:
+    out_dir = Path(output).expanduser().resolve() if output else default_output_dir(uid)
+    return {
+        "dry_run": True,
+        "would": {
+            "uid": uid,
+            "output_dir": str(out_dir),
+            "video_limit": video_limit,
+            "mode": "sequential (one video at a time, never parallel)",
+            "endpoints": [
+                "GET /x/web-interface/nav (WBI key discovery)",
+                "GET /x/space/wbi/arc/search (WBI-signed, paginated)",
+                "-- per video --",
+                "GET /x/web-interface/view",
+                "GET /x/tag/archive/tags",
+                "GET /x/v2/reply/main (paginated)",
+                "GET /x/v2/reply/reply (per thread with rcount>0)",
+            ],
+            "rate_limit": f"1.0s between API calls; {INTER_VIDEO_SLEEP_MIN}-{INTER_VIDEO_SLEEP_MAX}s random between videos",
+            "note": "fetch-user is resume-safe: already-completed BVIDs are skipped on re-run.",
+        },
+    }

--- a/plugins/bbc/skills/bbc-skill/bbc/fetch_user.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/fetch_user.py
@@ -27,13 +27,17 @@ def default_output_dir(uid: int) -> Path:
     return (Path.cwd() / "bilibili-comments" / f"user-{uid}").resolve()
 
 
-def _list_all_videos(client: api.Client, uid: int, img_key: str, sub_key: str, *, limit: int | None) -> list[dict]:
+def _list_all_videos(
+    client: api.Client, uid: int, img_key: str, sub_key: str, *, limit: int | None
+) -> list[dict]:
     """Paginate through all user videos. Returns list of dicts with bvid/title/play/comment/created."""
     videos: list[dict] = []
     pn = 1
     ps = 30
     while True:
-        data = api.list_user_videos(client, uid, img_key=img_key, sub_key=sub_key, pn=pn, ps=ps)
+        data = api.list_user_videos(
+            client, uid, img_key=img_key, sub_key=sub_key, pn=pn, ps=ps
+        )
         vlist = (data.get("data", {}).get("list", {}) or {}).get("vlist") or []
         page_info = (data.get("data", {}).get("page", {})) or {}
         for v in vlist:
@@ -76,7 +80,10 @@ def run_fetch_user(
     video_limit: int | None,
     max_top: int | None,
     progress: Progress,
-    inter_video_sleep_range: tuple[float, float] = (INTER_VIDEO_SLEEP_MIN, INTER_VIDEO_SLEEP_MAX),
+    inter_video_sleep_range: tuple[float, float] = (
+        INTER_VIDEO_SLEEP_MIN,
+        INTER_VIDEO_SLEEP_MAX,
+    ),
 ) -> dict[str, Any]:
     out_dir = Path(output).expanduser().resolve() if output else default_output_dir(uid)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -112,16 +119,28 @@ def run_fetch_user(
         if not bvid:
             continue
         if bvid in completed:
-            progress.progress(phase="skip_video", idx=idx, total=len(videos), bvid=bvid, reason="already_done")
+            progress.progress(
+                phase="skip_video",
+                idx=idx,
+                total=len(videos),
+                bvid=bvid,
+                reason="already_done",
+            )
             continue
 
         video_out = out_dir / bvid
         progress.progress(
-            phase="video_start", idx=idx, total=len(videos),
-            bvid=bvid, title=v.get("title"), declared_comments=v.get("comment"),
+            phase="video_start",
+            idx=idx,
+            total=len(videos),
+            bvid=bvid,
+            title=v.get("title"),
+            declared_comments=v.get("comment"),
         )
 
-        sub_progress = Progress("fetch-user.video", progress.request_id, enabled=progress.enabled)
+        sub_progress = Progress(
+            "fetch-user.video", progress.request_id, enabled=progress.enabled
+        )
         try:
             result = fetch.run_fetch(
                 target=bvid,
@@ -143,8 +162,11 @@ def run_fetch_user(
             )
             completed.add(bvid)
             progress.progress(
-                phase="video_done", idx=idx, total=len(videos),
-                bvid=bvid, counts=result.get("counts"),
+                phase="video_done",
+                idx=idx,
+                total=len(videos),
+                bvid=bvid,
+                counts=result.get("counts"),
             )
         except api.ApiError as e:
             err_rec = {
@@ -220,7 +242,9 @@ def run_fetch_user(
     }
 
 
-def run_dry_run(uid: int, output: str | None, video_limit: int | None) -> dict[str, Any]:
+def run_dry_run(
+    uid: int, output: str | None, video_limit: int | None
+) -> dict[str, Any]:
     out_dir = Path(output).expanduser().resolve() if output else default_output_dir(uid)
     return {
         "dry_run": True,

--- a/plugins/bbc/skills/bbc-skill/bbc/flatten.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/flatten.py
@@ -1,0 +1,74 @@
+"""Convert raw API replies into flat JSONL rows."""
+
+from datetime import datetime, timezone
+
+
+def _iso_utc(ts: int) -> str:
+    try:
+        return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat(timespec="seconds")
+    except (ValueError, OverflowError, OSError):
+        return ""
+
+
+def _ip_location(reply: dict) -> str:
+    raw = (reply.get("reply_control", {}) or {}).get("location") or ""
+    member_loc = (reply.get("member", {}) or {}).get("ip_location") or ""
+    val = raw or member_loc
+    if not val:
+        return ""
+    # Strip "IP属地：" or "IP属地:" prefix
+    for prefix in ("IP属地：", "IP属地:"):
+        if val.startswith(prefix):
+            return val[len(prefix):].strip()
+    return val.strip()
+
+
+def _members_mentions(content: dict) -> list[dict]:
+    members = content.get("members") or []
+    out = []
+    for m in members:
+        if isinstance(m, dict):
+            out.append({"mid": m.get("mid"), "uname": m.get("uname") or m.get("name")})
+    return out
+
+
+def _jump_urls(content: dict) -> list[str]:
+    jump = content.get("jump_url") or {}
+    if isinstance(jump, dict):
+        return sorted({str(k) for k in jump.keys()})
+    return []
+
+
+def flatten_reply(reply: dict, *, bvid: str, owner_mid: int | None, top_type: int = 0) -> dict:
+    """One API reply dict -> one JSONL row (omits sub-replies; caller flattens those)."""
+    member = reply.get("member") or {}
+    content = reply.get("content") or {}
+    ctime = int(reply.get("ctime") or 0)
+    mid = int(member.get("mid") or 0)
+    level = ((member.get("level_info") or {}).get("current_level")) or 0
+    vip_info = (member.get("vip") or {})
+    vip = bool(vip_info.get("vipStatus") or vip_info.get("status"))
+
+    return {
+        "rpid": int(reply.get("rpid") or 0),
+        "rpid_str": str(reply.get("rpid_str") or reply.get("rpid") or ""),
+        "oid": int(reply.get("oid") or 0),
+        "bvid": bvid,
+        "parent": int(reply.get("parent") or 0),
+        "root": int(reply.get("root") or 0),
+        "mid": mid,
+        "uname": member.get("uname") or "",
+        "user_level": int(level),
+        "vip": vip,
+        "sex": member.get("sex") or "",
+        "ctime": ctime,
+        "ctime_iso": _iso_utc(ctime),
+        "message": content.get("message") or "",
+        "like": int(reply.get("like") or 0),
+        "rcount": int(reply.get("rcount") or 0),
+        "ip_location": _ip_location(reply),
+        "is_up_reply": bool(owner_mid and mid == owner_mid),
+        "top_type": int(top_type),
+        "mentioned_users": _members_mentions(content),
+        "jump_urls": _jump_urls(content),
+    }

--- a/plugins/bbc/skills/bbc-skill/bbc/flatten.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/flatten.py
@@ -19,7 +19,7 @@ def _ip_location(reply: dict) -> str:
     # Strip "IP属地：" or "IP属地:" prefix
     for prefix in ("IP属地：", "IP属地:"):
         if val.startswith(prefix):
-            return val[len(prefix):].strip()
+            return val[len(prefix) :].strip()
     return val.strip()
 
 
@@ -39,14 +39,16 @@ def _jump_urls(content: dict) -> list[str]:
     return []
 
 
-def flatten_reply(reply: dict, *, bvid: str, owner_mid: int | None, top_type: int = 0) -> dict:
+def flatten_reply(
+    reply: dict, *, bvid: str, owner_mid: int | None, top_type: int = 0
+) -> dict:
     """One API reply dict -> one JSONL row (omits sub-replies; caller flattens those)."""
     member = reply.get("member") or {}
     content = reply.get("content") or {}
     ctime = int(reply.get("ctime") or 0)
     mid = int(member.get("mid") or 0)
     level = ((member.get("level_info") or {}).get("current_level")) or 0
-    vip_info = (member.get("vip") or {})
+    vip_info = member.get("vip") or {}
     vip = bool(vip_info.get("vipStatus") or vip_info.get("status"))
 
     return {

--- a/plugins/bbc/skills/bbc-skill/bbc/progress.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/progress.py
@@ -1,0 +1,58 @@
+"""NDJSON progress events on stderr."""
+
+import json
+import sys
+import time
+from typing import Any
+
+
+class Progress:
+    """Emit one-line JSON progress events to stderr.
+
+    Silent if stderr is not a TTY AND BBC_PROGRESS is unset — keeps
+    piped/captured runs clean. Force-on with BBC_PROGRESS=1.
+    """
+
+    def __init__(self, command: str, request_id: str, *, enabled: bool | None = None):
+        self.command = command
+        self.request_id = request_id
+        if enabled is None:
+            import os
+
+            env = os.environ.get("BBC_PROGRESS", "").lower()
+            if env in ("1", "true", "yes"):
+                enabled = True
+            elif env in ("0", "false", "no"):
+                enabled = False
+            else:
+                enabled = sys.stderr.isatty() if hasattr(sys.stderr, "isatty") else False
+        self.enabled = enabled
+        self._t0 = time.monotonic()
+
+    def _emit(self, event: str, **fields: Any) -> None:
+        if not self.enabled:
+            return
+        payload = {
+            "event": event,
+            "command": self.command,
+            "request_id": self.request_id,
+            "elapsed_ms": int((time.monotonic() - self._t0) * 1000),
+            **fields,
+        }
+        try:
+            sys.stderr.write(json.dumps(payload, ensure_ascii=False) + "\n")
+            sys.stderr.flush()
+        except Exception:
+            pass
+
+    def start(self, **fields: Any) -> None:
+        self._emit("start", **fields)
+
+    def progress(self, **fields: Any) -> None:
+        self._emit("progress", **fields)
+
+    def complete(self, **fields: Any) -> None:
+        self._emit("complete", **fields)
+
+    def warn(self, message: str, **fields: Any) -> None:
+        self._emit("warn", message=message, **fields)

--- a/plugins/bbc/skills/bbc-skill/bbc/progress.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/progress.py
@@ -25,7 +25,9 @@ class Progress:
             elif env in ("0", "false", "no"):
                 enabled = False
             else:
-                enabled = sys.stderr.isatty() if hasattr(sys.stderr, "isatty") else False
+                enabled = (
+                    sys.stderr.isatty() if hasattr(sys.stderr, "isatty") else False
+                )
         self.enabled = enabled
         self._t0 = time.monotonic()
 

--- a/plugins/bbc/skills/bbc-skill/bbc/schema.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/schema.py
@@ -1,0 +1,183 @@
+"""Command parameter schemas — single source of truth for argparse, help, and
+`bbc schema` introspection.
+"""
+
+from bbc import SCHEMA_VERSION
+
+BV_PATTERN = r"^BV[A-Za-z0-9]{10}$"
+
+EXIT_CODES = {
+    "0": "success",
+    "1": "runtime or API error",
+    "2": "auth error (cookie invalid/missing)",
+    "3": "validation error (bad parameter)",
+    "4": "network error (timeout / retries exhausted)",
+}
+
+ERROR_CODES = {
+    "validation_error": {"exit": 3, "retryable": False},
+    "auth_required": {"exit": 2, "retryable": True, "retry_after_auth": True},
+    "auth_expired": {"exit": 2, "retryable": True, "retry_after_auth": True},
+    "not_found": {"exit": 1, "retryable": False},
+    "rate_limited": {"exit": 1, "retryable": True},
+    "api_error": {"exit": 1, "retryable": False},
+    "network_error": {"exit": 4, "retryable": True},
+    "internal_error": {"exit": 1, "retryable": False},
+}
+
+COMMANDS = {
+    "fetch": {
+        "since": "1.0.0",
+        "tier": "open",
+        "summary": "Fetch all comments (top-level + nested + pinned) for a single video.",
+        "params": {
+            "target": {
+                "type": "string",
+                "required": True,
+                "description": "BV number or full Bilibili video URL.",
+                "pattern": BV_PATTERN + " | bilibili URL",
+                "positional": True,
+            },
+            "max": {
+                "type": "integer",
+                "min": 1,
+                "default": None,
+                "description": "Max top-level comments to fetch (default: all).",
+            },
+            "since": {
+                "type": "string",
+                "format": "date-time or date",
+                "default": None,
+                "description": "Only fetch comments newer than this timestamp (ISO-8601).",
+            },
+            "output": {
+                "type": "string",
+                "default": "./bilibili-comments/<bvid>",
+                "description": "Output directory.",
+            },
+            "cookie_file": {
+                "type": "string",
+                "default": None,
+                "description": "Path to Netscape cookie file (overrides auto-detect).",
+            },
+            "browser": {
+                "type": "string",
+                "enum": ["auto", "firefox", "chrome", "edge", "safari"],
+                "default": "auto",
+                "description": "Which browser to auto-detect cookies from.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "table"],
+                "default": "json (non-TTY) / table (TTY)",
+                "description": "Stdout format.",
+            },
+            "dry_run": {
+                "type": "boolean",
+                "default": False,
+                "description": "Preview request plan without network calls.",
+            },
+            "force": {
+                "type": "boolean",
+                "default": False,
+                "description": "Ignore existing state; refetch from scratch.",
+            },
+        },
+    },
+    "fetch-user": {
+        "since": "1.0.0",
+        "tier": "open",
+        "summary": "Batch fetch comments for all videos of a UP主 by UID.",
+        "params": {
+            "uid": {
+                "type": "integer",
+                "required": True,
+                "description": "UP主 UID (member id).",
+                "positional": True,
+            },
+            "output": {
+                "type": "string",
+                "default": "./bilibili-comments/user-<uid>",
+                "description": "Output directory.",
+            },
+            "video_limit": {
+                "type": "integer",
+                "min": 1,
+                "default": None,
+                "description": "Limit how many of the UP's recent videos to fetch.",
+            },
+            "max": {"type": "integer", "min": 1, "default": None, "description": "Per-video top-level cap."},
+            "cookie_file": {"type": "string", "default": None, "description": "See fetch."},
+            "browser": {"type": "string", "enum": ["auto", "firefox", "chrome", "edge", "safari"], "default": "auto"},
+            "format": {"type": "string", "enum": ["json", "table"], "default": "auto"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+    },
+    "summarize": {
+        "since": "1.0.0",
+        "tier": "open",
+        "summary": "Rebuild summary.json from an existing comments.jsonl directory.",
+        "params": {
+            "directory": {
+                "type": "string",
+                "required": True,
+                "description": "Path to fetch output dir (must contain comments.jsonl).",
+                "positional": True,
+            },
+            "format": {"type": "string", "enum": ["json", "table"], "default": "auto"},
+        },
+    },
+    "cookie-check": {
+        "since": "1.0.0",
+        "tier": "open",
+        "summary": "Validate cookie and print logged-in user info.",
+        "params": {
+            "cookie_file": {"type": "string", "default": None, "description": "Path to cookie file (optional)."},
+            "browser": {"type": "string", "enum": ["auto", "firefox", "chrome", "edge", "safari"], "default": "auto"},
+            "format": {"type": "string", "enum": ["json", "table"], "default": "auto"},
+        },
+    },
+    "schema": {
+        "since": "1.0.0",
+        "tier": "open",
+        "summary": "Return JSON schema for a command (or all commands).",
+        "params": {
+            "command": {
+                "type": "string",
+                "required": False,
+                "description": "Command name; omit to dump all.",
+                "positional": True,
+            },
+        },
+    },
+}
+
+
+def describe(command: str | None = None) -> dict:
+    if command and command in COMMANDS:
+        return {
+            "command": command,
+            "schema_version": SCHEMA_VERSION,
+            **COMMANDS[command],
+            "envelope": _envelope_contract(),
+            "exit_codes": EXIT_CODES,
+            "error_codes": ERROR_CODES,
+        }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "commands": {name: spec["summary"] for name, spec in COMMANDS.items()},
+        "envelope": _envelope_contract(),
+        "exit_codes": EXIT_CODES,
+        "error_codes": ERROR_CODES,
+    }
+
+
+def _envelope_contract() -> dict:
+    return {
+        "success": {"ok": True, "data": "<object>", "meta": {"request_id": "str", "latency_ms": "int", "schema_version": "str"}},
+        "failure": {
+            "ok": False,
+            "error": {"code": "str", "message": "str", "retryable": "bool", "field?": "str", "retry_after_auth?": "bool"},
+            "meta": {"request_id": "str", "latency_ms": "int", "schema_version": "str"},
+        },
+    }

--- a/plugins/bbc/skills/bbc-skill/bbc/schema.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/schema.py
@@ -106,9 +106,22 @@ COMMANDS = {
                 "default": None,
                 "description": "Limit how many of the UP's recent videos to fetch.",
             },
-            "max": {"type": "integer", "min": 1, "default": None, "description": "Per-video top-level cap."},
-            "cookie_file": {"type": "string", "default": None, "description": "See fetch."},
-            "browser": {"type": "string", "enum": ["auto", "firefox", "chrome", "edge", "safari"], "default": "auto"},
+            "max": {
+                "type": "integer",
+                "min": 1,
+                "default": None,
+                "description": "Per-video top-level cap.",
+            },
+            "cookie_file": {
+                "type": "string",
+                "default": None,
+                "description": "See fetch.",
+            },
+            "browser": {
+                "type": "string",
+                "enum": ["auto", "firefox", "chrome", "edge", "safari"],
+                "default": "auto",
+            },
             "format": {"type": "string", "enum": ["json", "table"], "default": "auto"},
             "dry_run": {"type": "boolean", "default": False},
         },
@@ -132,8 +145,16 @@ COMMANDS = {
         "tier": "open",
         "summary": "Validate cookie and print logged-in user info.",
         "params": {
-            "cookie_file": {"type": "string", "default": None, "description": "Path to cookie file (optional)."},
-            "browser": {"type": "string", "enum": ["auto", "firefox", "chrome", "edge", "safari"], "default": "auto"},
+            "cookie_file": {
+                "type": "string",
+                "default": None,
+                "description": "Path to cookie file (optional).",
+            },
+            "browser": {
+                "type": "string",
+                "enum": ["auto", "firefox", "chrome", "edge", "safari"],
+                "default": "auto",
+            },
             "format": {"type": "string", "enum": ["json", "table"], "default": "auto"},
         },
     },
@@ -174,10 +195,20 @@ def describe(command: str | None = None) -> dict:
 
 def _envelope_contract() -> dict:
     return {
-        "success": {"ok": True, "data": "<object>", "meta": {"request_id": "str", "latency_ms": "int", "schema_version": "str"}},
+        "success": {
+            "ok": True,
+            "data": "<object>",
+            "meta": {"request_id": "str", "latency_ms": "int", "schema_version": "str"},
+        },
         "failure": {
             "ok": False,
-            "error": {"code": "str", "message": "str", "retryable": "bool", "field?": "str", "retry_after_auth?": "bool"},
+            "error": {
+                "code": "str",
+                "message": "str",
+                "retryable": "bool",
+                "field?": "str",
+                "retry_after_auth?": "bool",
+            },
             "meta": {"request_id": "str", "latency_ms": "int", "schema_version": "str"},
         },
     }

--- a/plugins/bbc/skills/bbc-skill/bbc/summarize.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/summarize.py
@@ -1,0 +1,154 @@
+"""Build summary.json from a comments.jsonl + video meta."""
+
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+from bbc import SCHEMA_VERSION
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _iso_utc(ts: int) -> str:
+    try:
+        return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat(timespec="seconds")
+    except (ValueError, OverflowError, OSError):
+        return ""
+
+
+def _preview(text: str, n: int = 80) -> str:
+    t = (text or "").replace("\n", " ").strip()
+    return t[:n] + ("…" if len(t) > n else "")
+
+
+def build_summary(
+    *,
+    jsonl_path: Path,
+    video_meta: dict,
+    fetch_range: dict,
+    declared_all_count: int | None,
+    top_n: int = 20,
+) -> dict:
+    # stream-read jsonl
+    rows: list[dict] = []
+    with jsonl_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    total = len(rows)
+    top_level = sum(1 for r in rows if r.get("parent", 0) == 0 and r.get("top_type", 0) == 0)
+    nested = sum(1 for r in rows if r.get("parent", 0) != 0)
+    pinned = sum(1 for r in rows if r.get("top_type", 0) != 0)
+    unique_users = len({r.get("mid") for r in rows if r.get("mid")})
+    up_replies = sum(1 for r in rows if r.get("is_up_reply"))
+
+    ctimes = [r["ctime"] for r in rows if r.get("ctime")]
+    earliest = min(ctimes) if ctimes else 0
+    latest = max(ctimes) if ctimes else 0
+
+    by_day = Counter()
+    for r in rows:
+        iso = r.get("ctime_iso")
+        if iso and len(iso) >= 10:
+            by_day[iso[:10]] += 1
+    by_day_list = [{"date": d, "count": c} for d, c in sorted(by_day.items())]
+
+    top_liked = sorted(rows, key=lambda r: r.get("like", 0), reverse=True)[:top_n]
+    top_liked_out = [
+        {
+            "rpid": r.get("rpid"),
+            "uname": r.get("uname"),
+            "mid": r.get("mid"),
+            "like": r.get("like"),
+            "parent": r.get("parent"),
+            "is_up_reply": r.get("is_up_reply"),
+            "ctime_iso": r.get("ctime_iso"),
+            "message_preview": _preview(r.get("message", "")),
+        }
+        for r in top_liked
+    ]
+
+    top_replied_pool = [r for r in rows if r.get("parent", 0) == 0]
+    top_replied = sorted(top_replied_pool, key=lambda r: r.get("rcount", 0), reverse=True)[:top_n]
+    top_replied_out = [
+        {
+            "rpid": r.get("rpid"),
+            "uname": r.get("uname"),
+            "rcount": r.get("rcount"),
+            "like": r.get("like"),
+            "ctime_iso": r.get("ctime_iso"),
+            "message_preview": _preview(r.get("message", "")),
+        }
+        for r in top_replied
+    ]
+
+    ip_counter = Counter(r.get("ip_location") or "未知" for r in rows)
+    ip_dist = dict(sorted(ip_counter.items(), key=lambda x: x[1], reverse=True))
+
+    completeness = None
+    if declared_all_count:
+        completeness = round(total / declared_all_count, 4)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "fetched_at": _iso_now(),
+        "fetch_range": fetch_range,
+        "video": video_meta,
+        "counts": {
+            "total": total,
+            "top_level": top_level,
+            "nested": nested,
+            "pinned": pinned,
+            "declared_all_count": declared_all_count,
+            "completeness": completeness,
+            "unique_users": unique_users,
+            "up_replies": up_replies,
+        },
+        "time_distribution": {
+            "earliest_iso": _iso_utc(earliest),
+            "latest_iso": _iso_utc(latest),
+            "by_day": by_day_list,
+        },
+        "top_liked": top_liked_out,
+        "top_replied": top_replied_out,
+        "ip_distribution": ip_dist,
+    }
+
+
+def video_meta_from_view(view: dict, tags: list[dict]) -> dict:
+    stat = view.get("stat") or {}
+    owner = view.get("owner") or {}
+    return {
+        "bvid": view.get("bvid"),
+        "aid": view.get("aid"),
+        "cid": view.get("cid"),
+        "title": view.get("title"),
+        "desc": view.get("desc"),
+        "pubdate_iso": _iso_utc(int(view.get("pubdate") or 0)),
+        "ctime_iso": _iso_utc(int(view.get("ctime") or 0)),
+        "duration_seconds": view.get("duration"),
+        "cover_url": view.get("pic"),
+        "tname": view.get("tname"),
+        "owner": {"mid": owner.get("mid"), "name": owner.get("name"), "face": owner.get("face")},
+        "stat": {
+            "view": stat.get("view"),
+            "like": stat.get("like"),
+            "coin": stat.get("coin"),
+            "favorite": stat.get("favorite"),
+            "reply": stat.get("reply"),
+            "danmaku": stat.get("danmaku"),
+            "share": stat.get("share"),
+            "his_rank": stat.get("his_rank"),
+            "now_rank": stat.get("now_rank"),
+        },
+        "tags": [t.get("tag_name") for t in (tags or []) if t.get("tag_name")],
+    }

--- a/plugins/bbc/skills/bbc-skill/bbc/summarize.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/summarize.py
@@ -45,7 +45,9 @@ def build_summary(
                 continue
 
     total = len(rows)
-    top_level = sum(1 for r in rows if r.get("parent", 0) == 0 and r.get("top_type", 0) == 0)
+    top_level = sum(
+        1 for r in rows if r.get("parent", 0) == 0 and r.get("top_type", 0) == 0
+    )
     nested = sum(1 for r in rows if r.get("parent", 0) != 0)
     pinned = sum(1 for r in rows if r.get("top_type", 0) != 0)
     unique_users = len({r.get("mid") for r in rows if r.get("mid")})
@@ -78,7 +80,9 @@ def build_summary(
     ]
 
     top_replied_pool = [r for r in rows if r.get("parent", 0) == 0]
-    top_replied = sorted(top_replied_pool, key=lambda r: r.get("rcount", 0), reverse=True)[:top_n]
+    top_replied = sorted(
+        top_replied_pool, key=lambda r: r.get("rcount", 0), reverse=True
+    )[:top_n]
     top_replied_out = [
         {
             "rpid": r.get("rpid"),
@@ -138,7 +142,11 @@ def video_meta_from_view(view: dict, tags: list[dict]) -> dict:
         "duration_seconds": view.get("duration"),
         "cover_url": view.get("pic"),
         "tname": view.get("tname"),
-        "owner": {"mid": owner.get("mid"), "name": owner.get("name"), "face": owner.get("face")},
+        "owner": {
+            "mid": owner.get("mid"),
+            "name": owner.get("name"),
+            "face": owner.get("face"),
+        },
         "stat": {
             "view": stat.get("view"),
             "like": stat.get("like"),

--- a/plugins/bbc/skills/bbc-skill/bbc/wbi.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/wbi.py
@@ -14,10 +14,70 @@ import time
 import urllib.parse
 
 MIXIN_KEY_ENC_TAB = [
-    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
-    27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
-    37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4,
-    22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
+    46,
+    47,
+    18,
+    2,
+    53,
+    8,
+    23,
+    32,
+    15,
+    50,
+    10,
+    31,
+    58,
+    3,
+    45,
+    35,
+    27,
+    43,
+    5,
+    49,
+    33,
+    9,
+    42,
+    19,
+    29,
+    28,
+    14,
+    39,
+    12,
+    38,
+    41,
+    13,
+    37,
+    48,
+    7,
+    16,
+    24,
+    55,
+    40,
+    61,
+    26,
+    17,
+    0,
+    1,
+    60,
+    51,
+    30,
+    4,
+    22,
+    25,
+    54,
+    21,
+    56,
+    59,
+    6,
+    63,
+    57,
+    62,
+    11,
+    36,
+    20,
+    34,
+    44,
+    52,
 ]
 
 _BAD_CHARS = "!'()*"
@@ -40,7 +100,9 @@ def sign(params: dict, img_key: str, sub_key: str, *, now: int | None = None) ->
     signed = dict(params)
     signed["wts"] = int(now if now is not None else time.time())
     # Strip special chars from values
-    cleaned = {k: "".join(c for c in str(v) if c not in _BAD_CHARS) for k, v in signed.items()}
+    cleaned = {
+        k: "".join(c for c in str(v) if c not in _BAD_CHARS) for k, v in signed.items()
+    }
     query = urllib.parse.urlencode(sorted(cleaned.items()))
     # pi-lens-ignore: python-weak-hash  # B站 WBI 签名协议固定要求 MD5(w_rid)，非安全场景
     signed["w_rid"] = hashlib.md5((query + mixin).encode("utf-8")).hexdigest()

--- a/plugins/bbc/skills/bbc-skill/bbc/wbi.py
+++ b/plugins/bbc/skills/bbc-skill/bbc/wbi.py
@@ -1,0 +1,52 @@
+"""WBI signing for Bilibili endpoints that require it (e.g. space/arc search).
+
+Algorithm reference:
+1. Fetch nav endpoint to get img_url and sub_url
+2. Extract filename stems (64 chars total = 32 + 32)
+3. Apply MIXIN_KEY_ENC_TAB permutation, take first 32 chars -> mixin_key
+4. Sort params alphabetically, strip special chars from values
+5. Append wts=<unix_ts>
+6. MD5(query_string + mixin_key) -> w_rid
+"""
+
+import hashlib
+import time
+import urllib.parse
+
+MIXIN_KEY_ENC_TAB = [
+    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
+    27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
+    37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4,
+    22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
+]
+
+_BAD_CHARS = "!'()*"
+
+
+def _mixin_key(orig: str) -> str:
+    return "".join(orig[i] for i in MIXIN_KEY_ENC_TAB)[:32]
+
+
+def keys_from_nav(nav_data: dict) -> tuple[str, str]:
+    img_url = nav_data["wbi_img"]["img_url"]
+    sub_url = nav_data["wbi_img"]["sub_url"]
+    img_key = img_url.rsplit("/", 1)[1].split(".")[0]
+    sub_key = sub_url.rsplit("/", 1)[1].split(".")[0]
+    return img_key, sub_key
+
+
+def sign(params: dict, img_key: str, sub_key: str, *, now: int | None = None) -> dict:
+    mixin = _mixin_key(img_key + sub_key)
+    signed = dict(params)
+    signed["wts"] = int(now if now is not None else time.time())
+    # Strip special chars from values
+    cleaned = {k: "".join(c for c in str(v) if c not in _BAD_CHARS) for k, v in signed.items()}
+    query = urllib.parse.urlencode(sorted(cleaned.items()))
+    # pi-lens-ignore: python-weak-hash  # B站 WBI 签名协议固定要求 MD5(w_rid)，非安全场景
+    signed["w_rid"] = hashlib.md5((query + mixin).encode("utf-8")).hexdigest()
+    return signed
+
+
+def signed_url(base_url: str, params: dict, img_key: str, sub_key: str) -> str:
+    s = sign(params, img_key, sub_key)
+    return f"{base_url}?{urllib.parse.urlencode(s)}"

--- a/plugins/bbc/skills/bbc-skill/cookie-extraction.md
+++ b/plugins/bbc/skills/bbc-skill/cookie-extraction.md
@@ -1,0 +1,116 @@
+# Cookie extraction per platform
+
+The skill needs a valid `SESSDATA` cookie and (ideally) `bili_jct`,
+`DedeUserID`, `buvid3`. Priority at load time:
+
+1. `--cookie-file <path>` (CLI flag)
+2. `$BBC_COOKIE_FILE` env var
+3. `$BBC_SESSDATA` env var (direct value)
+4. `~/.config/bbc-skill/cookie.json` (cached)
+5. Auto-detect from installed browsers
+
+## Recommended: browser extension export
+
+Fastest, works identically across OSes.
+
+### Chrome / Edge
+
+[**Get cookies.txt LOCALLY**](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
+
+- Install from Chrome Web Store
+- Visit <https://www.bilibili.com> (stay logged in)
+- Click extension icon → **Export** → save as `www.bilibili.com_cookies.txt`
+- Pass to the CLI via `--cookie-file` or `$BBC_COOKIE_FILE`
+
+### Firefox
+
+[cookies.txt](https://addons.mozilla.org/firefox/addon/cookies-txt/) add-on,
+same workflow.
+
+### Safari
+
+Safari does not have a first-party cookies.txt extension. Either:
+
+- Use Firefox / Chrome for B站 login, export from there, or
+- Use the built-in auto-detect (`--browser safari`) which parses
+  `~/Library/Cookies/Cookies.binarycookies`
+
+## Auto-detection (fallback)
+
+Set `--browser auto` (default). The skill probes, in order:
+
+1. Firefox — `cookies.sqlite` via stdlib `sqlite3`, unencrypted
+2. Chrome (macOS) — SQLite + Keychain AES-128-CBC decryption via `security`
+   and `openssl` CLI (both system-built-in)
+3. Edge (macOS) — same as Chrome, different Keychain service
+
+Windows and Linux Chrome paths are stubbed for this release — use the
+extension export instead.
+
+### Chrome / Edge on macOS — how decryption works
+
+1. Cookie DB: `~/Library/Application Support/Google/Chrome/<profile>/Cookies`
+   (or `Profile 1/Cookies`, etc.)
+2. Encrypted value format: `v10` or `v11` prefix + AES-128-CBC ciphertext
+3. Key derivation:
+   - Fetch password via `security find-generic-password -w -s "Chrome Safe Storage" -a Chrome`
+   - PBKDF2-SHA1, salt=`saltysalt`, iter=1003, dklen=16
+4. Decryption: `openssl enc -d -aes-128-cbc -K <hex> -iv <hex>` with IV =
+   16 spaces (`b' ' * 16`)
+
+All tools (`security`, `openssl`) are macOS system binaries, so no
+`pip install` required.
+
+### Firefox
+
+On all OSes Firefox stores cookies in `cookies.sqlite` with values in
+plaintext. The skill copies the DB to a temp file (avoids WAL locks),
+queries via stdlib `sqlite3`, and returns the row.
+
+### Safari
+
+Safari cookies live at `~/Library/Cookies/Cookies.binarycookies`, a custom
+binary plist format. Parser not implemented in this release; recommend
+exporting via extension from Chrome/Firefox instead.
+
+## Storing cookies long-term
+
+Two safe-ish options:
+
+**Option A — local file, permission 600**
+
+```bash
+cp ~/Downloads/bilibili_cookies.txt ~/.config/bbc-skill/cookie.txt
+chmod 600 ~/.config/bbc-skill/cookie.txt
+export BBC_COOKIE_FILE=~/.config/bbc-skill/cookie.txt
+```
+
+**Option B — env var (shell profile)**
+
+```bash
+# in ~/.zshrc or ~/.bashrc
+export BBC_SESSDATA="your_sessdata_value"
+```
+
+Environment variables are slightly more agent-friendly because they don't
+require a filesystem round-trip, but they're visible to other processes
+run from the same shell.
+
+## Rotating / revoking
+
+`SESSDATA` is rotated by:
+
+- Clicking "退出登录" in any Bilibili session (invalidates all sessions)
+- Waiting for natural expiry (~2 weeks of inactivity)
+
+After rotation, re-export from the browser and update your cookie file
+or env var.
+
+## What NOT to do
+
+- **Do not share** `SESSDATA` in bug reports, screenshots, or public
+  repositories — it authorizes full account access including posting,
+  deleting content, changing account settings.
+- **Do not commit** the cookie file to version control.
+- **Do not transmit** the cookie to third parties or external services;
+  this skill only calls `api.bilibili.com` directly.


### PR DESCRIPTION
Standard layout plugins/bbc/skills/bbc-skill/ (SKILL.md + src/bbc/ + scripts/ + references/), README/LICENSE at plugin root, marketplace.json entry bbc v1.0.4 MIT. Includes the lint-blocking fixes (TLS/typing/hardcoded-hash suppressions) and the standalone repo's pending autofix commit (already pushed to Agents365-ai/bbc-skill). Verified: bbc schema returns a valid envelope. Do not merge; awaiting review.