### PR TITLE
Point bbc skill references at the 365-skills monorepo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "author": {
         "name": "Agents365-ai"
       },
-      "repository": "https://github.com/Agents365-ai/bbc-skill",
+      "repository": "https://github.com/Agents365-ai/365-skills",
       "license": "MIT",
       "keywords": [
         "bilibili",

--- a/plugins/bbc/README.md
+++ b/plugins/bbc/README.md
@@ -51,21 +51,24 @@
 ## Install
 
 It is a plain, self-contained skill: Python 3.9+ stdlib only, zero pip
-install. Clone it into any coding-agent skills directory and it works:
+install. The skill lives in the Agents365-ai skills monorepo; clone the
+monorepo and link or copy the skill directory into your agent's skills path:
 
 ```bash
 # Global (Claude Code example; other agents read their own skills path)
-git clone https://github.com/Agents365-ai/bbc-skill.git ~/.claude/skills/bbc-skill
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/bbc/skills/bbc-skill" ~/.claude/skills/bbc-skill
 
 # Project-level
-git clone https://github.com/Agents365-ai/bbc-skill.git .claude/skills/bbc-skill
+ln -s "$(pwd)/365-skills/plugins/bbc/skills/bbc-skill" .claude/skills/bbc-skill
 ```
 
 Or run it standalone without any skill runtime:
 
 ```bash
-git clone https://github.com/Agents365-ai/bbc-skill.git && cd bbc-skill
-./scripts/bbc --help
+git clone https://github.com/Agents365-ai/365-skills.git
+cd 365-skills/plugins/bbc/skills/bbc-skill
+python3 -m bbc --help
 ```
 
 ---
@@ -303,7 +306,7 @@ See `references/agent-contract.md` for the full schema.
 Suggestions, bug reports, and pull requests are all welcome. If you have
 ideas — new analysis workflows, better anti-bot defaults, additional
 platform support, documentation fixes — feel free to
-[open an issue](https://github.com/Agents365-ai/bbc-skill/issues) or
+[open an issue](https://github.com/Agents365-ai/365-skills/issues) or
 submit a PR directly.
 
 This skill is community-friendly: every contribution, no matter how small,

--- a/plugins/bbc/README_CN.md
+++ b/plugins/bbc/README_CN.md
@@ -36,21 +36,24 @@
 ## 安装
 
 这是一个纯自包含的常规 skill:只用 Python 3.9+ 标准库，零 `pip install`。
-任意 coding agent 的 skill 目录，clone 进去就能用：
+skill 位于 Agents365-ai 的 skills monorepo；clone 整个 monorepo，再把 skill 目录
+链接或复制到 agent 的 skills 路径：
 
 ```bash
 # 全局（以 Claude Code 为例；其他 agent 用各自的 skills 路径）
-git clone https://github.com/Agents365-ai/bbc-skill.git ~/.claude/skills/bbc-skill
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/bbc/skills/bbc-skill" ~/.claude/skills/bbc-skill
 
 # 项目级
-git clone https://github.com/Agents365-ai/bbc-skill.git .claude/skills/bbc-skill
+ln -s "$(pwd)/365-skills/plugins/bbc/skills/bbc-skill" .claude/skills/bbc-skill
 ```
 
 不走 skill 运行时、直接命令行用也可以：
 
 ```bash
-git clone https://github.com/Agents365-ai/bbc-skill.git && cd bbc-skill
-./scripts/bbc --help
+git clone https://github.com/Agents365-ai/365-skills.git
+cd 365-skills/plugins/bbc/skills/bbc-skill
+python3 -m bbc --help
 ```
 
 ---
@@ -268,7 +271,7 @@ python3 -m bbc fetch-user 441831884 --video-limit 2   # 先小批量试跑
 
 ## 贡献
 
-欢迎提 issue、PR、建议。无论是新的分析场景、更稳的反风控默认值、其他平台支持、文档改进 —— 任何贡献都欢迎。[提 Issue](https://github.com/Agents365-ai/bbc-skill/issues) 或直接发 PR。
+欢迎提 issue、PR、建议。无论是新的分析场景、更稳的反风控默认值、其他平台支持、文档改进 —— 任何贡献都欢迎。[提 Issue](https://github.com/Agents365-ai/365-skills/issues) 或直接发 PR。
 
 ---
 

--- a/plugins/bbc/skills/bbc-skill/SKILL.md
+++ b/plugins/bbc/skills/bbc-skill/SKILL.md
@@ -2,7 +2,7 @@
 name: bbc-skill
 description: Fetch Bilibili (哔哩哔哩) video comments for UP主 self-analysis. Use when the user asks to collect, download, export, or analyze comments on a Bilibili video (BV号 / URL / UID). Produces JSONL + summary.json suitable for further Claude Code analysis (sentiment, keywords, audience trends). Read-only; does not post/edit/delete.
 license: MIT
-homepage: https://github.com/Agents365-ai/bbc-skill
+homepage: https://github.com/Agents365-ai/365-skills/tree/main/plugins/bbc/skills/bbc-skill
 metadata: {"version":"1.0.4","openclaw":{"requires":{"bins":["python3"]},"emoji":"💬"},"hermes":{"category":"data","tags":["bilibili","comments","up主","scraping","chinese"]}}
 ---
 


### PR DESCRIPTION
Prep for retiring the standalone Agents365-ai/bbc-skill repo (all content lives at plugins/bbc/skills/bbc-skill since v1.0.4).

- README.md / README_CN.md install instructions: clone the monorepo and symlink/copy the skill dir; standalone run block now uses python3 -m bbc (the scripts/bbc wrapper no longer exists)
- Issue/contribution links -> 365-skills/issues
- SKILL.md homepage -> skill path in the monorepo
- marketplace.json bbc plugin repository -> 365-skills

Remaining docs-only breakage (pre-existing, out of scope): 6 further `./scripts/bbc` call sites in README/README_CN below the install section still reference the removed wrapper; all command examples should become `python3 -m bbc` run from plugins/bbc/skills/bbc-skill.