### PR TITLE
Move paper-fetch standalone docs into the 365-skills monorepo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -178,7 +178,7 @@
       "author": {
         "name": "Agents365-ai"
       },
-      "repository": "https://github.com/Agents365-ai/paper-fetch",
+      "repository": "https://github.com/Agents365-ai/365-skills",
       "license": "MIT",
       "keywords": [
         "paper",

--- a/plugins/paper-fetch/LICENSE
+++ b/plugins/paper-fetch/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/paper-fetch/README.md
+++ b/plugins/paper-fetch/README.md
@@ -1,0 +1,222 @@
+# paper-fetch — Download scientific paper PDFs by DOI
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-paper-fetch-skills-paper-fetch-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/paper-fetch-pro-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+**English** · [中文](README_CN.md) · [📖 Online Docs](https://agents365-ai.github.io/paper-fetch/)
+
+Resolve a DOI (or title) to a PDF via a 7-source fallback chain — [Unpaywall](https://unpaywall.org) → [Semantic Scholar](https://www.semanticscholar.org) → [arXiv](https://arxiv.org) → [PubMed Central](https://pmc.ncbi.nlm.nih.gov) → [bioRxiv](https://www.biorxiv.org)/[medRxiv](https://www.medrxiv.org) → publisher direct → [Sci-Hub](https://www.sci-hub.pub) mirrors. Pure Python stdlib, agent-native CLI with stable JSON envelopes.
+
+## What it does
+
+**Resolve a DOI (or title) to a PDF**
+
+- 7-source fallback chain: [Unpaywall](https://unpaywall.org) → [Semantic Scholar](https://www.semanticscholar.org) → [arXiv](https://arxiv.org) → [PubMed Central](https://pmc.ncbi.nlm.nih.gov) → [bioRxiv](https://www.biorxiv.org)/[medRxiv](https://www.medrxiv.org) → publisher direct *(institutional opt-in)* → [Sci-Hub](https://www.sci-hub.pub) mirrors *(last resort, on by default)*
+- Title-only input via `--title` — Crossref + Semantic Scholar resolution with confidence flags
+- Auto-named output: `{first_author}_{year}_{journal_abbrev}_{short_title}.pdf`
+
+**Batch + agent-friendly**
+
+- `--batch dois.txt` or `--batch -` (stdin) for bulk download
+- `--idempotency-key` replays the exact envelope on retry without network I/O
+- `--stream` emits one NDJSON result per line as each DOI resolves
+- Skips already-downloaded files unless `--overwrite`
+
+**Built-in correctness**
+
+- Stable JSON envelope on stdout, NDJSON progress on stderr, machine-readable `schema` subcommand
+- TTY-aware format default, typed exit codes (`0`/`1`/`3`/`4`) for orchestrator routing
+- SSRF defense + `%PDF` magic-byte check + 50 MB size cap on every fetch
+- Zero runtime dependencies — pure Python stdlib
+
+**Cloudflare-blocked PDFs** *(opt-in)*
+
+- `PAPER_FETCH_CLOAK=1` retries any 403/429-blocked or JS-challenged PDF URL through [CloakBrowser](https://github.com/CloakHQ/CloakBrowser), a stealth Chromium that passes the challenge (approach borrowed from [cloakFetch](https://github.com/Agents365-ai/cloakFetch))
+- Sits at the download layer, so it applies to every source; off by default, fails closed, operator-controlled
+- Returned bytes re-validated through the same `%PDF` + size checks; result carries `via: "cloak"`
+
+Works with Claude Code, Codex, Hermes, OpenClaw, ClawHub, pi-mono, and SkillsMP — any agent that supports the [Agent Skills](https://agentskills.io) format.
+
+## Discipline coverage
+
+The skill is **discipline-agnostic** — it works for any field, not just life sciences or CS.
+
+| Source | Discipline scope |
+| --- | --- |
+| Unpaywall | ✅ All disciplines (every Crossref DOI — humanities, social sciences, physics, chemistry, economics) |
+| Semantic Scholar | ✅ All disciplines (cross-domain academic graph) |
+| arXiv | Physics, math, CS, statistics, quant finance, economics, EE |
+| PubMed Central | Biomedical only |
+| bioRxiv / medRxiv | Biology / medicine preprints only |
+| Sci-Hub | ✅ All disciplines (last resort) |
+
+In practice, **Unpaywall + Semantic Scholar alone cover OA papers in chemistry, materials, economics, psychology, humanities, and every other field** via institutional repositories, SSRN, RePEc, and publisher-hosted OA copies.
+
+## Comparison
+
+### vs. native agent (no skill)
+
+| Feature | Native agent | This skill |
+| --- | --- | --- |
+| Resolve DOI to PDF | Ad-hoc web search | Deterministic 7-source chain |
+| Title → DOI resolution | Manual | `--title` (Crossref + S2 fallback, confidence flags) |
+| Batch download | ❌ | ✅ `--batch dois.txt` or `--batch -` |
+| Consistent filenames | ❌ | ✅ `author_year_journal_title.pdf` |
+| Machine-readable schema | ❌ | ✅ `fetch.py schema` |
+| Structured output | ❌ | ✅ JSON envelope + NDJSON progress |
+| Idempotent retries | ❌ | ✅ `--idempotency-key` |
+| Typed exit codes | ❌ | ✅ `0`/`1`/`3`/`4` |
+| SSRF + `%PDF` + size cap | ❌ | ✅ enforced |
+
+## Prerequisites
+
+- `python3` (3.8+, stdlib only — no `pip install` needed)
+- (Recommended) An [Unpaywall contact email](https://unpaywall.org/products/api):
+
+  ```bash
+  export UNPAYWALL_EMAIL=you@example.com
+  ```
+
+Without it, Unpaywall is skipped and the remaining 6 sources still work.
+
+## Installation
+
+```bash
+# Any agent (Claude Code, Cursor, Copilot, etc.)
+npx skills add Agents365-ai/365-skills -g
+
+# Claude Code only
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install paper-fetch
+```
+
+Also published on [SkillsMP](https://skillsmp.com/) and [ClawHub](https://clawhub.ai/) — each handles updates through its own marketplace.
+
+## Usage
+
+Just describe what you want:
+
+```
+> Download the AlphaFold2 paper PDF to ~/papers
+
+> Fetch DOI 10.1038/s41586-020-2649-2
+
+> Batch-download every DOI from dois.txt
+
+> Find a PDF for "Attention Is All You Need" and save it
+
+> Preview the resolved PDF URL for 10.1126/science.abj8754 without downloading
+```
+
+Or call the script directly:
+
+```bash
+# Single DOI
+python skills/paper-fetch/scripts/fetch.py 10.1038/s41586-021-03819-2
+
+# By title (resolved to DOI via Crossref + S2 fallback)
+python skills/paper-fetch/scripts/fetch.py --title "Highly accurate protein structure prediction with AlphaFold"
+
+# Dry-run preview (no download)
+python skills/paper-fetch/scripts/fetch.py 10.1038/s41586-020-2649-2 --dry-run
+
+# Batch with idempotency
+python skills/paper-fetch/scripts/fetch.py --batch dois.txt --out ~/papers \
+    --idempotency-key monday-review-batch
+
+# Pipe DOIs from another tool
+echo 10.1038/s41586-021-03819-2 | python skills/paper-fetch/scripts/fetch.py --batch -
+
+# Agent discovery
+python skills/paper-fetch/scripts/fetch.py schema --pretty
+```
+
+Full flag reference and JSON envelope schema in [`skills/paper-fetch/SKILL.md`](skills/paper-fetch/SKILL.md).
+
+## Institutional access (opt-in)
+
+If your institution has a subscription, set `PAPER_FETCH_INSTITUTIONAL=1` to enable the publisher-direct fallback. Your IP / cookies / EZproxy authorize the fetch; the skill adds a 1 req/s rate limiter to keep batch jobs within publisher ToS.
+
+```bash
+export PAPER_FETCH_INSTITUTIONAL=1
+```
+
+## Cloudflare-blocked PDFs via CloakBrowser (opt-in)
+
+Some publishers (e.g. `science.org`) sit behind Cloudflare, which serves a `403`/`429` or a "Just a moment…" JS challenge to plain HTTP clients instead of the PDF. Set `PAPER_FETCH_CLOAK=1` to retry those URLs through [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) — a stealth Chromium that passes the challenge. The approach is borrowed from [cloakFetch](https://github.com/Agents365-ai/cloakFetch).
+
+```bash
+# Requires a Python with `cloakbrowser` importable (pip install cloakbrowser)
+export PAPER_FETCH_CLOAK=1
+export CLOAKBROWSER_PYTHON="$HOME/github/CloakBrowser/.venv/bin/python"  # if not auto-detected
+export PAPER_FETCH_CLOAK_HEADED=1   # for hard challenges (e.g. science.org) that defeat headless
+```
+
+The fallback lives at the download layer (so it covers every source), re-validates returned bytes through the same `%PDF` + 50 MB checks, fails closed when CloakBrowser is unavailable, and is operator-controlled — the agent cannot enable it. Successful cloak downloads carry `via: "cloak"` in the result.
+
+By default the browser runs **headless**; harder challenges (e.g. `science.org`) get stuck on "Just a moment…" in headless mode, so set `PAPER_FETCH_CLOAK_HEADED=1` for a visible window that clears them (needs a display). The in-page fetch is **same-origin**, so it works for direct PDF links on the blocked host (e.g. `www.science.org/doi/pdf/…`); cross-origin-redirecting URLs fall through. See [`skills/paper-fetch/SKILL.md`](skills/paper-fetch/SKILL.md) (*CloakBrowser access*) for details.
+
+## Known limitations
+
+- **Some publisher redirects** return an HTML landing page; the `%PDF` header check rejects them
+- **No browser automation** — no CAPTCHA solving, no Playwright, no stealth
+- **SSRF defense** rejects private IPs, non-http(s) schemes, non-80/443 ports, cloud metadata hosts
+- **50 MB cap** per PDF download
+
+## 🔗 Related Skills
+
+Part of the [Agents365-ai research-skill family](https://github.com/Agents365-ai) — pick the right tool for the job:
+
+| Skill | Niche | When to use |
+| --- | --- | --- |
+| [semanticscholar-skill](https://github.com/Agents365-ai/semanticscholar-skill) | Semantic Scholar API search | When you need to FIND papers before fetching |
+| [asta-skill](https://github.com/Agents365-ai/asta-skill) | Same corpus via Ai2 Asta MCP | When your host supports MCP and you have an Asta API key |
+| [scholar-deep-research](https://github.com/Agents365-ai/scholar-deep-research) | 8-phase literature review pipeline | When you want a structured cited report, not just PDFs |
+| [zotero-research-assistant](https://github.com/Agents365-ai/zotero-research-assistant) | Zotero library workflows | When references go into Zotero |
+
+## ❤️ Support
+
+If this skill helps you, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="Give a Reward">
+      <br>
+      <b>Give a Reward</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 Author
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/plugins/paper-fetch/README_CN.md
+++ b/plugins/paper-fetch/README_CN.md
@@ -1,0 +1,222 @@
+# paper-fetch — 按 DOI 自动下载论文 PDF
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/network/members)
+[![Latest Release](https://img.shields.io/github/v/release/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/releases/latest)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/commits/main)
+
+[![SkillsMP](https://img.shields.io/badge/SkillsMP-listed-1f6feb)](https://skillsmp.com/skills/agents365-ai-paper-fetch-skills-paper-fetch-skill-md)
+[![ClawHub](https://img.shields.io/badge/ClawHub-listed-ff6b35)](https://clawhub.ai/agents365-ai/paper-fetch-pro-skill)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-8a2be2)](https://github.com/Agents365-ai/365-skills)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+[English](README.md) · **中文** · [📖 在线文档](https://agents365-ai.github.io/paper-fetch/zh.html)
+
+将 DOI（或标题）解析为 PDF — 7 源回退链：[Unpaywall](https://unpaywall.org) → [Semantic Scholar](https://www.semanticscholar.org) → [arXiv](https://arxiv.org) → [PubMed Central](https://pmc.ncbi.nlm.nih.gov) → [bioRxiv](https://www.biorxiv.org)/[medRxiv](https://www.medrxiv.org) → 出版商直链 → [Sci-Hub](https://www.sci-hub.pub) 镜像。纯 Python 标准库，agent 原生 CLI，稳定 JSON 信封。
+
+## 功能简介
+
+**DOI（或标题）→ PDF**
+
+- 7 源回退链：[Unpaywall](https://unpaywall.org) → [Semantic Scholar](https://www.semanticscholar.org) → [arXiv](https://arxiv.org) → [PubMed Central](https://pmc.ncbi.nlm.nih.gov) → [bioRxiv](https://www.biorxiv.org)/[medRxiv](https://www.medrxiv.org) → 出版商直链 *（机构模式启用）* → [Sci-Hub](https://www.sci-hub.pub) 镜像 *（默认开启的兜底）*
+- 仅有标题时通过 `--title` 解析 — Crossref + Semantic Scholar 双路回退，附置信度标记
+- 自动命名：`{第一作者}_{年份}_{期刊简称}_{简短标题}.pdf`
+
+**批量 + Agent 友好**
+
+- `--batch dois.txt` 或 `--batch -`（stdin）批量下载
+- `--idempotency-key` 重试时直接复用原信封，无任何网络 I/O
+- `--stream` 在每个 DOI 解析完成时立即输出一行 NDJSON
+- 已下载文件默认跳过；`--overwrite` 强制覆盖
+
+**内置正确性保障**
+
+- stdout 稳定 JSON 信封，stderr NDJSON 进度，机器可读的 `schema` 子命令
+- `--format` 自动识别 TTY,退出码分类（`0`/`1`/`3`/`4`)便于 orchestrator 路由
+- 每次外部抓取都执行 SSRF 防护 + `%PDF` 魔数校验 + 50 MB 体积上限
+- 零运行时依赖 — 纯 Python 标准库
+
+**Cloudflare 拦截的 PDF** *(可选)*
+
+- `PAPER_FETCH_CLOAK=1` 会将被 403/429 拦截或遇到 JS 挑战的 PDF 链接,改用 [CloakBrowser](https://github.com/CloakHQ/CloakBrowser)(可通过挑战的隐身 Chromium)重试(方案借鉴自 [cloakFetch](https://github.com/Agents365-ai/cloakFetch))
+- 位于下载层,因此对所有源生效;默认关闭、失败时静默回退、仅由操作者控制
+- 返回的字节仍经过相同的 `%PDF` + 体积校验;结果带 `via: "cloak"` 标记
+
+兼容 Claude Code、Codex、Hermes、OpenClaw、ClawHub、pi-mono、SkillsMP — 所有支持 [Agent Skills](https://agentskills.io) 格式的 Agent。
+
+## 学科覆盖
+
+本 skill **学科无关**,不限于生命科学或 CS。
+
+| 来源 | 学科范围 |
+| --- | --- |
+| Unpaywall | ✅ 全学科(覆盖 Crossref 所有 DOI — 人文、社科、物理、化学、经济等) |
+| Semantic Scholar | ✅ 全学科(跨领域学术图谱) |
+| arXiv | 物理、数学、CS、统计、定量金融、经济学、EE |
+| PubMed Central | 仅生物医学 |
+| bioRxiv / medRxiv | 仅生物 / 医学预印本 |
+| Sci-Hub | ✅ 全学科(兜底) |
+
+实际使用中，**仅 Unpaywall + Semantic Scholar 两个源就足以覆盖化学、材料、经济、心理学、人文社科等任何领域的 OA 论文** — 它们会自动命中机构知识库、SSRN、RePEc 以及出版商自托管的 OA 版本。
+
+## 对比
+
+### vs 原生 agent(无 skill)
+
+| 功能 | 原生 agent | 本 skill |
+| --- | --- | --- |
+| DOI → PDF | 临时网络搜索 | 确定性 7 源链 |
+| 标题 → DOI | 手动 | `--title`(Crossref + S2 回退,附置信度标记) |
+| 批量下载 | ❌ | ✅ `--batch dois.txt` 或 `--batch -` |
+| 一致的文件命名 | ❌ | ✅ `author_year_journal_title.pdf` |
+| 机器可读 schema | ❌ | ✅ `fetch.py schema` |
+| 结构化输出 | ❌ | ✅ JSON 信封 + NDJSON 进度 |
+| 幂等重试 | ❌ | ✅ `--idempotency-key` |
+| 退出码分类 | ❌ | ✅ `0`/`1`/`3`/`4` |
+| SSRF + `%PDF` + 体积上限 | ❌ | ✅ 强制启用 |
+
+## 环境要求
+
+- `python3`(3.8+,仅标准库,无需 `pip install`)
+- (推荐)[Unpaywall 联系邮箱](https://unpaywall.org/products/api):
+
+  ```bash
+  export UNPAYWALL_EMAIL=you@example.com
+  ```
+
+未设置时跳过 Unpaywall,其余 6 个源仍正常工作。
+
+## 安装
+
+```bash
+# 任意 Agent(Claude Code、Cursor、Copilot 等)
+npx skills add Agents365-ai/365-skills -g
+
+# 仅 Claude Code
+> /plugin marketplace add Agents365-ai/365-skills
+> /plugin install paper-fetch
+```
+
+也已发布到 [SkillsMP](https://skillsmp.com/) 与 [ClawHub](https://clawhub.ai/),它们各自的市场负责更新。
+
+## 使用
+
+直接用自然语言告诉 Agent:
+
+```
+> 把 AlphaFold2 论文的 PDF 下载到 ~/papers
+
+> 帮我下 DOI 10.1038/s41586-020-2649-2
+
+> 把 dois.txt 里的全部 DOI 批量下载
+
+> 找 "Attention Is All You Need" 这篇论文的 PDF 并保存
+
+> 不下载,只预览 10.1126/science.abj8754 解析出的 PDF 链接
+```
+
+或直接调用脚本:
+
+```bash
+# 单个 DOI
+python skills/paper-fetch/scripts/fetch.py 10.1038/s41586-021-03819-2
+
+# 仅有标题(经 Crossref + S2 回退解析为 DOI 后下载)
+python skills/paper-fetch/scripts/fetch.py --title "Highly accurate protein structure prediction with AlphaFold"
+
+# 干跑预览(不下载)
+python skills/paper-fetch/scripts/fetch.py 10.1038/s41586-020-2649-2 --dry-run
+
+# 批量 + 幂等键
+python skills/paper-fetch/scripts/fetch.py --batch dois.txt --out ~/papers \
+    --idempotency-key monday-review-batch
+
+# 从其他工具用管道传 DOI
+echo 10.1038/s41586-021-03819-2 | python skills/paper-fetch/scripts/fetch.py --batch -
+
+# Agent 自描述
+python skills/paper-fetch/scripts/fetch.py schema --pretty
+```
+
+完整参数与 JSON 信封 schema 见 [`skills/paper-fetch/SKILL.md`](skills/paper-fetch/SKILL.md)。
+
+## 机构访问(可选)
+
+如所在机构有出版商订阅,设 `PAPER_FETCH_INSTITUTIONAL=1` 启用出版商直链回退。授权由你的 IP / cookies / EZproxy 完成;为避免触发出版商 ToS, skill 会自动加 1 req/s 限速。
+
+```bash
+export PAPER_FETCH_INSTITUTIONAL=1
+```
+
+## 通过 CloakBrowser 抓取 Cloudflare 拦截的 PDF(可选)
+
+部分出版商(如 `science.org`)位于 Cloudflare 之后,会向普通 HTTP 客户端返回 `403`/`429` 或 "Just a moment…" JS 挑战页,而非 PDF。设 `PAPER_FETCH_CLOAK=1` 即可将这些链接改用 [CloakBrowser](https://github.com/CloakHQ/CloakBrowser)(可通过挑战的隐身 Chromium)重试。方案借鉴自 [cloakFetch](https://github.com/Agents365-ai/cloakFetch)。
+
+```bash
+# 需要一个可 import cloakbrowser 的 Python(pip install cloakbrowser)
+export PAPER_FETCH_CLOAK=1
+export CLOAKBROWSER_PYTHON="$HOME/github/CloakBrowser/.venv/bin/python"  # 若未自动识别
+export PAPER_FETCH_CLOAK_HEADED=1   # 针对 headless 无法通过的强挑战(如 science.org)
+```
+
+该回退位于下载层(覆盖所有源),返回字节仍经过相同的 `%PDF` + 50 MB 校验,CloakBrowser 不可用时静默回退,且仅由操作者控制 —— Agent 无法自行启用。成功的 cloak 下载结果带 `via: "cloak"`。
+
+浏览器默认 **headless**;较强的挑战(如 `science.org`)在 headless 下会卡在 "Just a moment…",此时设 `PAPER_FETCH_CLOAK_HEADED=1` 用可见窗口通过(需要显示环境)。页面内 fetch 为 **同源**,因此适用于被拦截主机上的直链 PDF(如 `www.science.org/doi/pdf/…`);跨源重定向的链接会静默回退。详见 [`skills/paper-fetch/SKILL.md`](skills/paper-fetch/SKILL.md)(*CloakBrowser access*)。
+
+## 已知限制
+
+- **部分出版商重定向**会返回 HTML 落地页,`%PDF` 魔数校验会拒绝
+- **默认不做浏览器自动化** — 不解 CAPTCHA、不用 Playwright、不做反指纹绕过。(浏览器自动化是独立的可选项:上面 `PAPER_FETCH_CLOAK` 控制的 CloakBrowser 回退。)
+- **SSRF 防护**会拒绝私网 IP、非 http(s) 协议、非 80/443 端口、云元数据主机
+- **每个 PDF 体积上限 50 MB**
+
+## 🔗 相关 Skills
+
+属于 [Agents365-ai 学术研究 skill 系列](https://github.com/Agents365-ai) —— 按需挑选合适的工具：
+
+| Skill | 定位 | 何时使用 |
+| --- | --- | --- |
+| [semanticscholar-skill](https://github.com/Agents365-ai/semanticscholar-skill) | Semantic Scholar API 检索 | 下载前先 **找** 论文时 |
+| [asta-skill](https://github.com/Agents365-ai/asta-skill) | 经 Ai2 Asta MCP 访问相同语料 | 宿主支持 MCP 且有 Asta API key 时 |
+| [scholar-deep-research](https://github.com/Agents365-ai/scholar-deep-research) | 8 阶段文献综述流水线 | 需要的不只是 PDF，而是带引用的结构化报告 |
+| [zotero-research-assistant](https://github.com/Agents365-ai/zotero-research-assistant) | Zotero 文献库工作流 | 把文献存进 Zotero 时 |
+
+## ❤️ 支持作者
+
+如果这个 skill 对你有帮助，欢迎打赏支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/awarding/award.gif" width="180" alt="打赏">
+      <br>
+      <b>打赏</b>
+    </td>
+  </tr>
+</table>
+
+## 👤 作者
+
+**Agents365-ai**
+
+- GitHub: <https://github.com/Agents365-ai>
+- Bilibili: <https://space.bilibili.com/441831884>
+
+## 📄 License
+
+[MIT](LICENSE)

--- a/plugins/paper-fetch/skills/paper-fetch/SKILL.md
+++ b/plugins/paper-fetch/skills/paper-fetch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-fetch
 description: Use whenever the user wants to obtain, download, or fetch a paper's PDF — given a DOI, an arXiv id, a paper title, a citation, or a list of DOIs. Trigger on phrases like "download this paper", "find the PDF for [DOI]", "grab me the [Nature/bioRxiv/arXiv] paper on X", "get the open-access version", "I need this article", or any bulk/batch paper download request, even when the user doesn't explicitly say "PDF" or "DOI". Resolves via Unpaywall → Semantic Scholar → arXiv → PubMed Central → bioRxiv/medRxiv → publisher direct (institutional opt-in) → Sci-Hub mirrors as last-resort fallback.
-homepage: https://github.com/Agents365-ai/paper-fetch
+homepage: https://github.com/Agents365-ai/365-skills
 metadata: {"openclaw":{"requires":{"bins":["python3"]},"emoji":"📄"},"pimo":{"category":"research","tags":["paper","pdf","doi","open-access","download"]},"author":"Agents365-ai","version":"0.15.1"}
 ---
 


### PR DESCRIPTION
Copies LICENSE + README.md + README_CN.md from the standalone Agents365-ai/paper-fetch repo into plugins/paper-fetch/ (plugin root), updates repo-referencing badges to the monorepo, drops the dangling plan/institutional-access.md link, and points SKILL.md homepage and the marketplace.json repository field at the monorepo. Version stays 0.15.1; skills/ scripts untouched (already synced).