### PR TITLE
Add obsidian-dev-rules plugin from the standalone repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -514,6 +514,27 @@
       ]
     },
     {
+      "name": "obsidian-dev-rules",
+      "source": "./plugins/obsidian-dev-rules",
+      "description": "Authoritative reference and rules for developing for Obsidian — building TypeScript plugins (Plugin lifecycle, manifest.json, commands, settings, modals, views, ribbon/status bar), the Vault and Editor APIs, the event system, Markdown post-processing & code-block processors, CodeMirror 6 editor extensions, building CSS themes (CSS variables, theme.css/manifest), and submitting plugins/themes to the community directory. Use whenever the user asks to build, debug, or review an Obsidian plugin or theme, work with the Obsidian API (Vault/Editor/Workspace/Plugin), register commands/views/events, process Markdown, or release/submit to the Obsidian community.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/365-skills",
+      "license": "MIT",
+      "keywords": [
+        "obsidian",
+        "plugin-development",
+        "typescript",
+        "codemirror",
+        "vault-api",
+        "themes",
+        "docs-reference",
+        "documentation"
+      ]
+    },
+    {
       "name": "obsidian-organizer",
       "source": "./plugins/obsidian-organizer",
       "description": "Keep a large Obsidian vault tidy — file new notes into the best-fit folder and audit/reorganize existing structure, driven by a single source-of-truth map note (00_Index/Folder_Map.md) that lives inside the vault. Link-safe by design: all moves/renames go through the obsidian CLI so wikilinks auto-repair, never raw shell. Propose-then-confirm for bulk reorganizations.",

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Install a single plugin (Claude Code): `/plugin install <plugin-name>`, e.g. `/p
 |---|---|
 | `obsidian-organizer` | Keep a large Obsidian vault tidy — file new notes into the best-fit folder and audit/reorganize existing structure, driven by a single source-of-truth map note (`00_Index/Folder_Map.md`) inside the vault. Link-safe by design (moves go through the `obsidian` CLI so wikilinks auto-repair), propose-then-confirm for bulk changes |
 | `zotero-dev-rules` | Zotero developer reference — Web API v3 (read/write, file upload, syncing, streaming, OAuth), the desktop client's internal JavaScript API, plugin development (Zotero 7–10), translators, and CSL citation styles |
+| `obsidian-dev-rules` | Obsidian developer reference — packaging of docs.obsidian.md for building/reviewing TypeScript plugins (Plugin lifecycle, Vault/Editor APIs, events, modals, views, CodeMirror 6) and CSS themes, plus community submission policies |
 
 ### Media & creative
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -63,6 +63,7 @@ npx skills add Agents365-ai/365-skills -g
 |---|---|
 | `obsidian-organizer` | 让庞大的 Obsidian 仓库保持整洁 —— 把新笔记归入最合适的文件夹，并按需审计/重组已有结构，以仓库内的唯一权威地图笔记（`00_Index/Folder_Map.md`）为准。设计上保证链接安全（移动/重命名都走 `obsidian` CLI，wikilink 自动修复，禁止裸 shell），批量重组先出方案再确认 |
 | `zotero-dev-rules` | Zotero 开发者参考 —— Web API v3（读写、文件上传、同步、流式、OAuth）、桌面客户端内部 JavaScript API、插件开发（Zotero 7–10）、转换器（translator）与 CSL 引文样式 |
+| `obsidian-dev-rules` | Obsidian 开发参考 —— 打包 docs.obsidian.md，用于构建/审查 TypeScript 插件（Plugin 生命周期、Vault/Editor API、事件、模态框、视图、CodeMirror 6）与 CSS 主题，并覆盖社区提交政策 |
 
 ### 媒体与创意
 

--- a/plugins/obsidian-dev-rules/LICENSE
+++ b/plugins/obsidian-dev-rules/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/obsidian-dev-rules/README.md
+++ b/plugins/obsidian-dev-rules/README.md
@@ -1,0 +1,91 @@
+# obsidian-dev-rules
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/network/members)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/commits/main)
+
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
+**English** · [中文](README_CN.md)
+
+A Claude Code / OpenClaw / Pi skill that packages the **Obsidian developer documentation**
+(https://docs.obsidian.md) as an on-demand reference, so an agent can build and review Obsidian
+plugins and themes without re-fetching the docs.
+
+Mirrors the Obsidian developer docs, fetched 2026-05-24.
+
+## What's inside
+
+- `SKILL.md` — overview, when-to-use, cheat sheet, hard rules, reference index.
+- `references/plugin-basics.md` — project setup, `manifest.json`, Plugin lifecycle, resource
+  registration/cleanup, the event system, dev workflow / hot reload, debugging.
+- `references/vault-and-editor.md` — Vault API (read/cachedRead/create/modify/process/delete,
+  TFile/TFolder, adapter, normalizePath), Editor API, Markdown post-processing & code-block
+  processors, CodeMirror 6 editor extensions.
+- `references/ui.md` — commands (callback variants, hotkeys), settings (PluginSettingTab,
+  load/saveData, Setting controls), modals (Modal/SuggestModal/FuzzySuggestModal), views (ItemView,
+  registerView, workspace leaves), ribbon/status bar.
+- `references/themes-and-release.md` — themes (CSS variables, theme.css/manifest, body classes,
+  snippets), submitting plugins & themes, developer policies & guidelines.
+
+## Install
+
+| Platform | Path |
+|----------|------|
+| Claude Code (global) | `~/.claude/skills/obsidian-dev-rules/` |
+| Claude Code (project) | `.claude/skills/obsidian-dev-rules/` |
+| OpenClaw (global) | `~/.openclaw/skills/obsidian-dev-rules/` |
+| Pi (global) | `~/.pi/agent/skills/obsidian-dev-rules/` |
+| Pi (project) | `.pi/skills/obsidian-dev-rules/` |
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/obsidian-dev-rules/skills/obsidian-dev-rules" ~/.claude/skills/obsidian-dev-rules
+```
+
+## Related skills
+
+Complements the Obsidian *usage* skills (obsidian-cli, obsidian-markdown, json-canvas,
+obsidian-bases) — this one is the **developer reference** for the Plugin/Vault/Editor APIs, themes,
+and the community submission process.
+
+## Updating
+
+Re-fetch the pages under https://docs.obsidian.md and regenerate `references/`; bump
+`metadata.fetched` in `SKILL.md`.
+
+## Support
+
+If this skill is helpful, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## Author
+
+**Agents365-ai** &mdash; building open-source skills for AI coding agents.
+
+- Bilibili: <https://space.bilibili.com/441831884>
+- GitHub: <https://github.com/Agents365-ai>
+
+## License
+
+[MIT](LICENSE) (this skill's packaging). Obsidian docs content © Dynalist Inc. / the Obsidian team.

--- a/plugins/obsidian-dev-rules/README_CN.md
+++ b/plugins/obsidian-dev-rules/README_CN.md
@@ -1,0 +1,89 @@
+# obsidian-dev-rules
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/Agents365-ai/365-skills?style=flat&logo=github)](https://github.com/Agents365-ai/365-skills/network/members)
+[![Last Commit](https://img.shields.io/github/last-commit/Agents365-ai/365-skills?logo=github)](https://github.com/Agents365-ai/365-skills/commits/main)
+
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-2ea44f)](https://agentskills.io)
+
+[English](README.md) · **中文**
+
+一个 Claude Code / OpenClaw / Pi 技能，把 **Obsidian 开发者文档**（https://docs.obsidian.md）
+打包成按需参考，让 agent 无需反复抓取文档即可构建和审查 Obsidian 插件与主题。
+
+镜像 Obsidian 开发者文档，抓取于 2026-05-24。
+
+## 内容结构
+
+- `SKILL.md` — 概览、适用场景、速查表、硬性规则、参考索引。
+- `references/plugin-basics.md` — 项目搭建、`manifest.json`、Plugin 生命周期、资源
+  注册与清理、事件系统、开发工作流 / 热重载、调试。
+- `references/vault-and-editor.md` — Vault API（read/cachedRead/create/modify/process/delete、
+  TFile/TFolder、adapter、normalizePath）、Editor API、Markdown 后处理与代码块处理器、
+  CodeMirror 6 编辑器扩展。
+- `references/ui.md` — 命令（callback 变体、快捷键）、设置（PluginSettingTab、load/saveData、
+  Setting 控件）、模态框（Modal/SuggestModal/FuzzySuggestModal）、视图（ItemView、
+  registerView、workspace leaves）、ribbon/状态栏。
+- `references/themes-and-release.md` — 主题（CSS 变量、theme.css/manifest、body 类、
+  snippets）、插件与主题的提交发布、开发者政策与准则。
+
+## 安装
+
+| 平台 | 路径 |
+|----------|------|
+| Claude Code（全局） | `~/.claude/skills/obsidian-dev-rules/` |
+| Claude Code（项目级） | `.claude/skills/obsidian-dev-rules/` |
+| OpenClaw（全局） | `~/.openclaw/skills/obsidian-dev-rules/` |
+| Pi（全局） | `~/.pi/agent/skills/obsidian-dev-rules/` |
+| Pi（项目级） | `.pi/skills/obsidian-dev-rules/` |
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/obsidian-dev-rules/skills/obsidian-dev-rules" ~/.claude/skills/obsidian-dev-rules
+```
+
+## 相关技能
+
+与 Obsidian *使用类*技能（obsidian-cli、obsidian-markdown、json-canvas、obsidian-bases）互补；
+本技能面向 Plugin/Vault/Editor API、主题与社区提交流程的**开发参考**。
+
+## 更新
+
+重新抓取 https://docs.obsidian.md 下的页面并重新生成 `references/`；同步更新
+`SKILL.md` 中的 `metadata.fetched`。
+
+## 支持
+
+如果这个技能对你有帮助，欢迎支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## 作者
+
+**Agents365-ai** &mdash; 为 AI 编码代理构建开源技能。
+
+- Bilibili：<https://space.bilibili.com/441831884>
+- GitHub：<https://github.com/Agents365-ai>
+
+## 许可证
+
+[MIT](LICENSE)（本技能的打包）。Obsidian 文档内容版权归 Dynalist Inc. / Obsidian 团队所有。

--- a/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/SKILL.md
+++ b/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: obsidian-dev-rules
+description: Authoritative reference and rules for developing for Obsidian — building TypeScript plugins (Plugin lifecycle, manifest.json, commands, settings, modals, views, ribbon/status bar), the Vault and Editor APIs, the event system, Markdown post-processing & code-block processors, CodeMirror 6 editor extensions, building CSS themes (CSS variables, theme.css/manifest), and submitting plugins/themes to the community directory. Use whenever the user asks to build, debug, or review an Obsidian plugin or theme, work with the Obsidian API (Vault/Editor/Workspace/Plugin), register commands/views/events, process Markdown, or release/submit to the Obsidian community.
+license: MIT
+metadata: {"source":"https://docs.obsidian.md/Home","docVersion":"latest","fetched":"2026-05-24"}
+---
+
+# Obsidian Dev Rules
+
+Obsidian is extended two ways: **plugins** (TypeScript against the Obsidian API) and **themes/snippets**
+(CSS). This skill mirrors the official developer docs at https://docs.obsidian.md so you can build and
+review Obsidian plugins/themes without re-fetching. The API ships as the `obsidian` npm package; the
+canonical starting point is the [`obsidian-sample-plugin`](https://github.com/obsidianmd/obsidian-sample-plugin).
+
+## When to use this skill
+
+- Building, debugging, or reviewing an **Obsidian plugin** (lifecycle, commands, settings, UI, views).
+- Reading/writing notes via the **Vault** API; manipulating the active note via the **Editor** API.
+- Subscribing to **events**, registering **Markdown post-processors** / code-block processors, or
+  **CodeMirror 6** editor extensions.
+- Building a **theme** (CSS variables, `theme.css`, manifest) or snippets.
+- **Releasing/submitting** a plugin or theme to the community directory.
+
+## Reference index — load the file you need
+
+| File | Covers |
+|------|--------|
+| `references/plugin-basics.md` | Project setup, `manifest.json`, Plugin lifecycle (`onload`/`onunload`), resource registration & cleanup, events, dev workflow / hot reload, debugging |
+| `references/vault-and-editor.md` | Vault API (read/cachedRead/create/modify/process/delete, TFile/TFolder, adapter, normalizePath), Editor API, Markdown post-processing & code-block processors, CodeMirror 6 editor extensions |
+| `references/ui.md` | Commands (callback variants, hotkeys), Settings (PluginSettingTab, load/saveData, Setting controls), Modals (Modal/SuggestModal/FuzzySuggestModal), Views (ItemView, registerView, workspace leaves), ribbon/status bar |
+| `references/themes-and-release.md` | Themes (CSS variables, theme.css/manifest, body classes, snippets), submitting plugins & themes, developer policies & guidelines |
+
+## Cheat sheet
+
+```ts
+import { Plugin, Notice, MarkdownView, TFile, normalizePath } from 'obsidian';
+
+export default class MyPlugin extends Plugin {
+  async onload() {
+    await this.loadSettings();
+    this.addRibbonIcon('dice', 'Greet', () => new Notice('Hello!'));
+    this.addCommand({ id: 'do-x', name: 'Do X', callback: () => {/* ... */} });
+    this.addSettingTab(new MySettingTab(this.app, this));
+    // Auto-cleaned on unload — always register through these:
+    this.registerEvent(this.app.vault.on('modify', (f) => {/* ... */}));
+    this.registerInterval(window.setInterval(() => {/* ... */}, 1000));
+    this.registerDomEvent(document, 'click', () => {/* ... */});
+  }
+  onunload() { /* release anything NOT registered via register*/ }
+}
+```
+
+```ts
+// Vault: prefer process() over read()+modify(); use cachedRead() for display only.
+const file = this.app.vault.getFileByPath('Notes/x.md');
+await this.app.vault.process(file, (data) => data.replace('foo', 'bar'));
+// Editor of the active note (preserves cursor/selection):
+const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+view?.editor.replaceSelection(view.editor.getSelection().toUpperCase());
+```
+
+**Plugin files**: `manifest.json` + `main.js` (+ optional `styles.css`) in `<vault>/.obsidian/plugins/<id>/`.
+**Theme files**: `manifest.json` + `theme.css` in `<vault>/.obsidian/themes/<name>/`.
+
+## Hard rules
+
+- **Use `this.app`, never the global `app`** (global exists for debugging only and may be removed).
+- **Register everything that needs teardown** via `registerEvent` / `registerInterval` /
+  `registerDomEvent` / `addCommand` / `registerView` / `registerMarkdownPostProcessor` — Obsidian
+  auto-cleans those on unload. Manually release anything else in `onunload()`. Leaked listeners/
+  intervals degrade Obsidian after the plugin is disabled.
+- **Never** use `innerHTML` / `outerHTML` / `insertAdjacentHTML` with dynamic content — build DOM with
+  `createEl()` / `createDiv()` / `createSpan()`.
+- **Prefer the Vault API over the Adapter API**; use `getFileByPath()` (not iterate-all); always
+  `normalizePath()` user-supplied paths. Use **`process()`** (atomic) instead of sequential
+  `read()`+`modify()` to avoid data loss; `cachedRead()` only when you won't write it back.
+- **For the active note, edit via the Editor interface**, not `Vault.modify` — it preserves the
+  cursor and selection.
+- **Don't store references to view instances**; Obsidian may recreate them — fetch with
+  `getLeavesOfType()` / `getActiveViewOfType()`.
+- **Don't set default hotkeys** for distributed plugins (OS-dependent, conflict-prone). UI text is
+  **sentence case**. Use CSS classes + Obsidian CSS variables, not hardcoded inline styles.
+- **`manifest.json` required fields**: `id`, `name`, `version` (semver `x.y.z`), `minAppVersion`,
+  `description`, `author`, `isDesktopOnly`. `id` must **not** contain "obsidian"; `name` is Basic-Latin,
+  no emoji/punctuation except hyphens.
+- **Release**: GitHub release whose **tag equals the manifest `version`**, with `main.js`,
+  `manifest.json`, and optional `styles.css` attached as **individual binary assets** (not zipped).
+- Use `async`/`await` (not Promise chains); `const`/`let` (not `var`).

--- a/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/plugin-basics.md
+++ b/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/plugin-basics.md
@@ -1,0 +1,113 @@
+# Obsidian Plugin Basics — Setup, Manifest, Lifecycle, Events
+
+Source: https://docs.obsidian.md/Plugins/Getting+started/{Build+a+plugin,Anatomy+of+a+plugin}, /Reference/Manifest, /Plugins/Events
+
+## Prerequisites & setup
+
+- Git, a Node.js dev environment, a code editor (VS Code recommended).
+- **Use a separate vault for development**, never your main vault.
+- Sample: `https://github.com/obsidianmd/obsidian-sample-plugin` (GitHub template).
+
+```bash
+cd path/to/vault
+mkdir -p .obsidian/plugins
+cd .obsidian/plugins
+git clone https://github.com/obsidianmd/obsidian-sample-plugin.git
+cd obsidian-sample-plugin
+npm install
+npm run dev        # watches source, rebuilds main.js on change (esbuild)
+```
+
+Enable it: Settings → Community plugins → turn on community plugins → toggle your plugin on.
+
+### Reloading after changes
+
+- **Source changes**: Command palette → "Reload app without saving", or toggle the plugin off/on.
+- **manifest.json changes**: restart Obsidian fully.
+- **Convenience**: install the community **Hot-Reload** plugin for auto-reload during dev.
+- **Debug**: open DevTools — `Ctrl+Shift+I` (Win/Linux) / `Cmd+Option+I` (macOS) → Console.
+
+## manifest.json
+
+| Field | Required | Type | Notes |
+|-------|----------|------|-------|
+| `id` | Yes | string | unique; **must not contain "obsidian"** |
+| `name` | Yes | string | Basic Latin only; no punctuation except hyphens; no emoji |
+| `version` | Yes | string | **semver** `x.y.z` |
+| `minAppVersion` | Yes | string | minimum Obsidian version |
+| `description` | Yes | string | |
+| `author` | Yes | string | |
+| `authorUrl` | No | string | |
+| `fundingUrl` | No | string \| object | single URL, or `{ "Label": "url", ... }` |
+| `isDesktopOnly` | Yes | boolean | `true` if it uses Node/Electron-only APIs |
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "minAppVersion": "1.0.0",
+  "description": "A helpful plugin for note-taking",
+  "author": "Jane Doe",
+  "authorUrl": "https://example.com",
+  "fundingUrl": { "Buy Me a Coffee": "https://buymeacoffee.com", "GitHub Sponsor": "https://github.com/sponsors" },
+  "isDesktopOnly": false
+}
+```
+
+Files that ship in `<vault>/.obsidian/plugins/<id>/`: `manifest.json`, `main.js`, optional `styles.css`.
+
+## The Plugin class & lifecycle
+
+The base `Plugin` class "defines the lifecycle of a plugin and exposes the operations available to all plugins."
+
+```ts
+import { Plugin } from 'obsidian';
+
+export default class ExamplePlugin extends Plugin {
+  async onload() {
+    // Runs when the user enables the plugin. Set up commands, UI, events, settings.
+  }
+  async onunload() {
+    // Runs on disable. Release anything NOT auto-registered (see below).
+  }
+}
+```
+
+**Cleanup is mandatory**: "any resources that your plugin is using must be released here to avoid
+affecting the performance of Obsidian after your plugin has been disabled."
+
+### Auto-cleaned registration helpers
+
+Prefer these — Obsidian detaches them automatically on unload, so you usually don't touch `onunload()`:
+
+- `this.addCommand(...)` — command palette entries.
+- `this.addRibbonIcon(icon, title, cb)` — left-ribbon button.
+- `this.addStatusBarItem()` — returns an element (desktop only).
+- `this.addSettingTab(tab)` — settings UI.
+- `this.registerEvent(ref)` — any Obsidian `EventRef` (vault/workspace/metadataCache).
+- `this.registerDomEvent(el, type, cb)` — DOM listener.
+- `this.registerInterval(window.setInterval(...))` — timers.
+- `this.registerView(type, factory)` — custom views.
+- `this.registerMarkdownPostProcessor(...)` / `registerMarkdownCodeBlockProcessor(...)`.
+- `this.registerEditorExtension([...])` — CodeMirror 6 extensions.
+
+## Events
+
+> "Any registered event handlers need to be detached whenever the plugin unloads." Always wrap in
+> `registerEvent()` so cleanup is automatic.
+
+```ts
+this.registerEvent(this.app.vault.on('create', (file) => {
+  console.log('a new file has entered the arena');
+}));
+
+// status bar updated every second; registerInterval ensures the timer is cleared on unload
+this.registerInterval(window.setInterval(() => this.updateStatusBar(), 1000));
+```
+
+**Vault events**: `create`, `modify`, `delete`, `rename`.
+**Workspace events**: `file-open`, `active-leaf-change`, `layout-change`, `quit`, etc.
+**MetadataCache events**: `changed`, `resolved`.
+
+Moment.js is bundled: `import { moment } from 'obsidian';`.

--- a/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/themes-and-release.md
+++ b/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/themes-and-release.md
@@ -1,0 +1,77 @@
+# Obsidian — Themes, Snippets, Releasing & Guidelines
+
+Source: https://docs.obsidian.md/Themes/App+themes/Build+a+theme, /Plugins/Releasing/{Submit+your+plugin,Plugin+guidelines}
+
+## Themes
+
+A theme is CSS that restyles Obsidian via its CSS custom properties. Obsidian exposes **400+ CSS
+variables**. Files live in `<vault>/.obsidian/themes/<name>/`.
+
+### Files
+
+- `manifest.json` — theme metadata (`name`, `version`, `minAppVersion`, `author`, `authorUrl`).
+  **The theme folder name must match the `name` exactly.** Restart Obsidian after edits.
+- `theme.css` — the stylesheet (CSS custom properties + rules).
+
+Sample: clone the official sample theme into `.obsidian/themes/`, then Settings → Appearance →
+Themes → select it.
+
+### Selectors
+
+- `body` — variables shared by **both** light and dark.
+- `:root` — variables available to all descendants.
+- `.theme-dark` / `.theme-light` — color-scheme-specific overrides (Obsidian sets one on `body`).
+
+```css
+body { --font-text-theme: Georgia, serif; }
+.theme-dark  { --background-primary: #18004F; --background-secondary: #220070; }
+.theme-light { --background-primary: #ECE4FF; --background-secondary: #D9C9FF; }
+:root { --input-hover-border-color: red; }
+```
+
+### Discovering variables
+
+DevTools (`Ctrl/Cmd+Shift+I`) → Sources → `app.css` (search variable names), or use the element
+inspector to find which variable styles a given UI element. Full list: the docs' "CSS variables" pages.
+
+### Snippets
+
+CSS snippets are single `.css` files in `<vault>/.obsidian/snippets/`, toggled in Settings →
+Appearance → CSS snippets — same variable/selector model, for small tweaks without a full theme.
+
+## Submitting a plugin
+
+**Repo root must contain**: `README.md` (purpose + usage), `LICENSE` (pick at choosealicense.com),
+`manifest.json`. Confirm compliance with the Developer Policies and Submission Requirements.
+
+**Release steps**:
+1. Bump `manifest.json` `version` (semver `x.y.z`).
+2. Create a **GitHub release whose tag exactly equals that version** (no `v` prefix mismatch).
+3. Attach as **individual binary assets**: `main.js`, `manifest.json`, and (optional) `styles.css`
+   — not a zip.
+4. At `community.obsidian.md`: sign in with your Obsidian account, link GitHub to verify ownership,
+   Plugins → New plugin → enter the repo URL, accept policies, submit. (Under the hood this opens a PR
+   adding your entry to `community-plugins.json` in the `obsidianmd/obsidian-releases` repo.)
+
+The system reads `manifest.json` from your default branch and downloads release assets matching that
+version. An **automated review** flags required fixes — address them, publish an incremented release,
+and the bot re-checks. Themes submit the same way (Themes → New theme), shipping `manifest.json` +
+`theme.css`.
+
+## Developer policies & guidelines (review checklist)
+
+- **Use `this.app`, not the global `app`** (debug-only, may be removed).
+- **Release every resource on unload.** Use `registerEvent()`, `addCommand()`, `registerInterval()`,
+  `registerDomEvent()`, `registerView()` so cleanup is automatic; manually clean anything else.
+- **Security**: never `innerHTML` / `outerHTML` / `insertAdjacentHTML` with dynamic input — build DOM
+  with `createEl()` / `createDiv()` / `createSpan()`.
+- **Files**: prefer the **Vault API** over the Adapter API; locate with `getFileByPath()` instead of
+  iterating all files; `normalizePath()` user paths. Use **`Vault.process()`** for atomic edits.
+- **Active note**: edit via the **Editor** interface (preserves cursor/selection), not `Vault.modify`.
+- **UI**: sentence case for all text; CSS classes + Obsidian CSS variables, **no hardcoded inline
+  styles**; **don't set default hotkeys**.
+- **Workspace/views**: use `getActiveViewOfType()` rather than `workspace.activeLeaf`; don't store
+  view references — fetch with `getLeavesOfType()` / `getActiveLeavesOfType()`.
+- **Mobile**: set `isDesktopOnly` correctly; avoid Node/Electron APIs unless desktop-only; avoid
+  lookbehind regex on older platforms.
+- **Code quality**: `const`/`let` over `var`; `async`/`await` over Promise chains.

--- a/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/ui.md
+++ b/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/ui.md
@@ -1,0 +1,158 @@
+# Obsidian Plugin UI — Commands, Settings, Modals, Views
+
+Source: https://docs.obsidian.md/Plugins/User+interface/{Commands,Settings,Modals,Views}
+
+## Commands
+
+Register in `onload()` with `this.addCommand({ id, name, ... })`. `id` is unique within the plugin;
+`name` shows in the Command Palette.
+
+### Callback variants (use exactly one)
+
+```ts
+// 1. Always available
+this.addCommand({ id: 'plain', name: 'Plain', callback: () => { /* run */ } });
+
+// 2. Conditional — return true if available; when checking===false, perform the action
+this.addCommand({ id: 'cond', name: 'Conditional', checkCallback: (checking) => {
+  const ok = canRun();
+  if (ok && !checking) doIt();
+  return ok;
+}});
+
+// 3. Needs an active editor (only shown when one exists)
+this.addCommand({ id: 'ed', name: 'Editor cmd', editorCallback: (editor, view) => { /* ... */ } });
+
+// 4. Conditional + editor
+this.addCommand({ id: 'edc', name: 'Editor cond', editorCheckCallback: (checking, editor, view) => {
+  const ok = editor.somethingSelected();
+  if (ok && !checking) act(editor);
+  return ok;
+}});
+```
+
+### Hotkeys
+
+```ts
+hotkeys: [{ modifiers: ['Mod', 'Shift'], key: 'a' }]
+```
+
+`'Mod'` = Cmd on macOS, Ctrl elsewhere. **Avoid shipping default hotkeys** in distributed plugins
+(conflict-prone, OS-dependent); let users assign them.
+
+## Settings
+
+Persist with `this.loadData()` / `this.saveData()` (one JSON blob → `data.json`). Provide a settings
+tab with `PluginSettingTab`.
+
+```ts
+interface MyPluginSettings { mySetting: string; }
+const DEFAULT_SETTINGS: MyPluginSettings = { mySetting: 'default' };
+
+export default class MyPlugin extends Plugin {
+  settings: MyPluginSettings;
+  async loadSettings() {
+    // shallow-merge defaults under loaded values
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+  async saveSettings() { await this.saveData(this.settings); }
+  async onload() {
+    await this.loadSettings();
+    this.addSettingTab(new MySettingTab(this.app, this));
+  }
+}
+
+import { App, PluginSettingTab, Setting } from 'obsidian';
+class MySettingTab extends PluginSettingTab {
+  plugin: MyPlugin;
+  constructor(app: App, plugin: MyPlugin) { super(app, plugin); this.plugin = plugin; }
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+    new Setting(containerEl)
+      .setName('My setting')
+      .setDesc('What it does')
+      .addText(text => text
+        .setPlaceholder('Enter value')
+        .setValue(this.plugin.settings.mySetting)
+        .onChange(async (value) => { this.plugin.settings.mySetting = value; await this.plugin.saveSettings(); }));
+  }
+}
+```
+
+> `Object.assign()` is a **shallow** copy — references to nested objects are shared. For nested
+> settings, deep-merge/clone to avoid mutating `DEFAULT_SETTINGS`.
+
+**Setting controls**: `addText`, `addTextArea`, `addToggle`, `addDropdown`, `addSlider`, `addSearch`,
+`addButton`, `addExtraButton`, `addColorPicker`, `addProgressBar`, `addMomentFormat`.
+Setting text uses **sentence case** ("Template folder location", not Title Case).
+
+## Modals
+
+```ts
+import { App, Modal, Setting } from 'obsidian';
+
+class InputModal extends Modal {
+  result = '';
+  constructor(app: App, public onSubmit: (r: string) => void) { super(app); }
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.createEl('h1', { text: 'Enter value' });
+    new Setting(contentEl).setName('Name').addText(t => t.onChange(v => this.result = v));
+    new Setting(contentEl).addButton(b => b.setButtonText('Submit').setCta()
+      .onClick(() => { this.close(); this.onSubmit(this.result); }));
+  }
+  onClose() { this.contentEl.empty(); }
+}
+// new InputModal(this.app, (r) => new Notice(r)).open();
+```
+
+- **`SuggestModal<T>`**: implement `getSuggestions(query)`, `renderSuggestion(item, el)`,
+  `onChooseSuggestion(item, evt)`.
+- **`FuzzySuggestModal<T>`**: fuzzy search out of the box — implement `getItems()`, `getItemText(item)`,
+  `onChooseItem(item, evt)`.
+
+## Views (custom panes)
+
+Extend `ItemView`; register the type in `onload()`; open it via a workspace leaf.
+
+```ts
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+export const VIEW_TYPE = 'my-view';
+
+export class MyView extends ItemView {
+  constructor(leaf: WorkspaceLeaf) { super(leaf); }
+  getViewType() { return VIEW_TYPE; }
+  getDisplayText() { return 'My view'; }
+  getIcon() { return 'dice'; }
+  async onOpen() { this.contentEl.createEl('h4', { text: 'Hello' }); }
+  async onClose() { /* cleanup */ }
+}
+```
+
+```ts
+// in onload()
+this.registerView(VIEW_TYPE, (leaf) => new MyView(leaf));
+this.addRibbonIcon('dice', 'Open my view', () => this.activateView());
+
+// activate without keeping a reference to the instance
+async activateView() {
+  const { workspace } = this.app;
+  let leaf = workspace.getLeavesOfType(VIEW_TYPE)[0];
+  if (!leaf) { leaf = workspace.getRightLeaf(false); await leaf.setViewState({ type: VIEW_TYPE, active: true }); }
+  workspace.revealLeaf(leaf);
+}
+```
+
+> **Don't store the view instance** — Obsidian may create it multiple times. Find it with
+> `getLeavesOfType()` / `getActiveViewOfType()`. (Clean up in `onunload()` by detaching leaves if needed.)
+
+## Ribbon & status bar
+
+```ts
+const ribbon = this.addRibbonIcon('dice', 'Tooltip', (evt) => new Notice('clicked'));
+const status = this.addStatusBarItem();   // desktop only
+status.setText('Ready');
+```
+
+Icons use Obsidian's built-in [Lucide](https://lucide.dev) set; register custom ones with `addIcon()`.

--- a/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/vault-and-editor.md
+++ b/plugins/obsidian-dev-rules/skills/obsidian-dev-rules/references/vault-and-editor.md
@@ -1,0 +1,119 @@
+# Obsidian — Vault, Editor, Markdown Processing, Editor Extensions
+
+Source: https://docs.obsidian.md/Plugins/Vault, /Plugins/Editor/{Editor,Markdown+post+processing}, editor extensions
+
+## Vault API
+
+A vault is "a folder, and any sub-folders within it." Access via `this.app.vault`.
+
+### Reading
+
+- `vault.cachedRead(file)` — for **display only** (no rewrite); reads from cache. Returns `Promise<string>`.
+- `vault.read(file)` — when you'll **modify and write back**.
+- Both reflect the latest content once the filesystem notifies Obsidian of a change.
+
+### Listing / locating
+
+- `vault.getMarkdownFiles()` — all `.md` `TFile`s.
+- `vault.getFiles()` — all files.
+- `vault.getFileByPath(path)` — a `TFile` or `null`.
+- `vault.getFolderByPath(path)` — a `TFolder` or `null`.
+- `vault.getAbstractFileByPath(path)` — a `TAbstractFile` (file or folder) or `null`.
+- Always `normalizePath(userPath)` before lookups with user-supplied paths.
+
+### Creating / modifying / deleting
+
+- `vault.create(path, data)` — new file → `Promise<TFile>`.
+- `vault.createFolder(path)`.
+- `vault.modify(file, data)` — overwrite a file's contents.
+- **`vault.process(file, (data) => newData)`** — atomic read-modify-write; "guarantees that the file
+  doesn't change between reading and writing." **Prefer over sequential `read()`/`modify()`** to avoid
+  data loss.
+- `vault.append(file, data)`.
+- `vault.rename(file, newPath)`, `vault.copy(file, newPath)`.
+- `vault.delete(file)` — permanent; `vault.trash(file, system)` — to OS trash (`true`) or `.trash` (`false`).
+
+### Type checks
+
+```ts
+import { TFile, TFolder } from 'obsidian';
+if (fileOrFolder instanceof TFile)   { /* it's a file */ }
+else if (fileOrFolder instanceof TFolder) { /* it's a folder */ }
+```
+
+### Adapter
+
+`vault.adapter` is the low-level filesystem API — use it **only** for hidden files/folders
+(e.g. inside `.obsidian`) that the Vault API doesn't see. Otherwise prefer the Vault API.
+
+## Editor API
+
+The `Editor` exposes the active Markdown document in edit mode. Get it via `editorCallback` in a
+command, or `this.app.workspace.getActiveViewOfType(MarkdownView)?.editor`.
+
+```ts
+import { MarkdownView, moment } from 'obsidian';
+
+// Insert today's date at the cursor
+this.addCommand({
+  id: 'insert-date', name: 'Insert date',
+  editorCallback: (editor) => editor.replaceRange(moment().format('YYYY-MM-DD'), editor.getCursor()),
+});
+
+// Uppercase the selection
+this.addCommand({
+  id: 'uppercase', name: 'Uppercase selection',
+  editorCallback: (editor) => editor.replaceSelection(editor.getSelection().toUpperCase()),
+});
+```
+
+Common methods: `getValue()` / `setValue()`, `getSelection()` / `replaceSelection(text)`,
+`getCursor()` / `setCursor(pos)`, `getLine(n)`, `lineCount()`, `getRange(from,to)`,
+`replaceRange(text, from[, to])` (one position = insert), `getDoc()`. **For the active note, use the
+Editor (preserves cursor/selection), not `Vault.modify`.**
+
+## Markdown post-processing (Reading view)
+
+Runs **after** Markdown → HTML. Register in `onload()`.
+
+```ts
+// Replace :emoji: inside the rendered output
+this.registerMarkdownPostProcessor((element, context) => {
+  // element: rendered DOM container; context: MarkdownPostProcessorContext
+  // walk element, add/remove/replace nodes
+});
+```
+
+### Code-block processor
+
+Turn a fenced block of a custom language into rendered output:
+
+````ts
+// ```csv\n a,b\n 1,2\n ```  →  an HTML table
+this.registerMarkdownCodeBlockProcessor('csv', (source, el, ctx) => {
+  const rows = source.split('\n').filter(r => r.length);
+  const table = el.createEl('table');
+  for (const row of rows) {
+    const tr = table.createEl('tr');
+    for (const cell of row.split(',')) tr.createEl('td', { text: cell });
+  }
+});
+````
+
+Args: code-block processor gets `(source, el, ctx)`; post-processor gets `(element, context)`.
+`ctx`/`context` is a `MarkdownPostProcessorContext` (sourcePath, frontmatter, `getSectionInfo(el)`,
+`addChild(component)` for lifecycle-bound child components).
+
+## Editor extensions (Live Preview / edit mode)
+
+Obsidian's editor is **CodeMirror 6**. Extend it by registering CM6 extensions:
+
+```ts
+import { ViewPlugin } from '@codemirror/view';
+// import { StateField, StateEffect } from '@codemirror/state';
+
+this.registerEditorExtension([ /* CM6 extensions: ViewPlugin, StateField, decorations, ... */ ]);
+```
+
+Use these for decorations (widgets/marks in the live editor), state fields, and viewport-aware
+rendering. Post-processors affect **Reading view**; editor extensions affect **edit/Live Preview**.


### PR DESCRIPTION
Move the obsidian-dev-rules skill (packaging of docs.obsidian.md) into the monorepo as `plugins/obsidian-dev-rules`.

- SKILL.md + references/ (4 md files), copied from the standalone repo
- MIT LICENSE added (none existed upstream), copyright Agents365-ai
- Bilingual READMEs (README.md + README_CN.md) pointing clone/badge URLs at Agents365-ai/365-skills, with Support/Author/License footer
- marketplace.json entry (version 0.1.0, MIT)
- Knowledge & notes table rows in both root READMEs

Source repo left untouched. Conflict with the zotero move resolved by keeping both table rows.