### PR TITLE
Move scientific-thinking-general skill into the 365-skills monorepo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -656,6 +656,27 @@
         "plugins",
         "developer-reference"
       ]
+    },
+    {
+      "name": "scientific-thinking-general",
+      "source": "./plugins/scientific-thinking-general",
+      "description": "Use when interpreting research findings, evaluating scientific evidence, analyzing mechanisms, comparing competing hypotheses, designing experiments, or constructing scientific arguments.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/365-skills",
+      "license": "MIT",
+      "keywords": [
+        "scientific-thinking",
+        "research",
+        "reasoning",
+        "evidence-evaluation",
+        "hypothesis",
+        "experiment-design",
+        "mechanism",
+        "peer-review"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install a single plugin (Claude Code): `/plugin install <plugin-name>`, e.g. `/p
 | `target-prioritization` | Multi-source drug-target due-diligence — turn a ranked gene list (e.g. scRNA-seq DE output) into a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan, then re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic |
 | `figshare` | Figshare v2 REST API — search public datasets/articles, batch-download files by ID/DOI/URL, and create, update, publish, or multi-part-upload to your own articles (large-file 3-step upload flow) |
 | `zenodo` | Zenodo REST API — deposit, publish, version, and search research artifacts (datasets, software, papers) with a citable DOI; sandbox-first, bucket-API uploads, full metadata reference and end-to-end shell examples |
+| `scientific-thinking-general` | Structured scientific reasoning meta-skill — separates fact / evidence / hypothesis, ranks competing explanations by support, calibrates conclusion language to evidence strength, and defines interpretation boundaries |
 
 ### Knowledge & notes
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,6 +56,7 @@ npx skills add Agents365-ai/365-skills -g
 | `target-prioritization` | 多源药物靶点尽职调查 —— 将排序基因列表（如 scRNA-seq 差异表达输出）转化为逐基因档案（UniProt、OpenTargets、PubMed），叠加本地跨谱系差异表达扫描，再按可配置综合评分（跨谱系趋同 + 成药性 + 疾病遗传学 + 可开发性 + 新颖性）重排。疾病无关，可配置靶疾病与细胞上下文查询 |
 | `figshare` | Figshare v2 REST API —— 搜索公开数据集/文章、按 ID/DOI/URL 批量下载文件，并可对自己账号的文章进行创建、更新、发布与多分片上传（大文件三步上传流程） |
 | `zenodo` | Zenodo REST API —— 存缴、发布、版本管理与检索研究成果（数据集、软件、论文）并获得可引用 DOI；默认先用 sandbox，支持 bucket API 上传，附完整元数据参考与端到端 Shell 示例 |
+| `scientific-thinking-general` | 结构化科学推理元技能 —— 区分事实/证据/假说、按支持度排序竞争性解释、结论措辞与证据强度校准、明确解释边界 |
 
 ### 知识与笔记
 

--- a/plugins/scientific-thinking-general/LICENSE
+++ b/plugins/scientific-thinking-general/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/scientific-thinking-general/README.md
+++ b/plugins/scientific-thinking-general/README.md
@@ -1,0 +1,178 @@
+# scientific-thinking — Structured Scientific Reasoning for AI Agents
+
+[中文文档](README_CN.md)
+
+## What it does
+
+- Frames and decomposes research questions before answering
+- Distinguishes observed fact / direct evidence / indirect evidence / hypothesis / speculation
+- Labels claim provenance: provided data vs. background knowledge vs. inference
+- Ranks competing explanations by available support
+- Calibrates conclusion language to evidence strength
+- Defines interpretation boundaries and unresolved uncertainty
+- Suggests the lowest-cost next step that would discriminate between explanations
+
+## Multi-Platform Support
+
+Works with all major AI agents that support the [Agent Skills](https://agentskills.io) format:
+
+| Platform | Status | Details |
+|----------|--------|---------|
+| **Claude Code** | ✅ Full support | Native SKILL.md format |
+| **OpenClaw / ClawHub** | ✅ Full support | `metadata.openclaw` namespace |
+| **Hermes Agent** | ✅ Full support | `metadata.hermes` namespace, category: research |
+| **Pi-Mo** | ✅ Full support | `metadata.pimo` namespace |
+| **OpenAI Codex** | ✅ Full support | `agents/openai.yaml` sidecar |
+| **SkillsMP** | ✅ Indexed | GitHub topics configured |
+
+## Comparison: with vs. without this skill
+
+| Capability | Native agent | This skill |
+|------------|-------------|------------|
+| Distinguish fact from interpretation | Sometimes | Always, explicitly labeled |
+| Label claim provenance | No | Yes — data / background / inference |
+| Consider alternative explanations | Inconsistent | Yes — ranked by support |
+| Calibrate language to evidence | No | Yes — 5-level scale |
+| State interpretation boundary | Rarely | Always |
+| Suggest discriminating next step | No | Yes |
+| Handle null results correctly | No | Yes — absence ≠ evidence of absence |
+| Reconcile conflicting papers | No | Yes — maps experimental differences |
+| Evidence provenance for missing data | No | Yes — labels answer as provisional |
+
+## When to use
+
+- Interpreting experimental results or paper conclusions
+- Evaluating competing hypotheses
+- Analyzing mechanisms or pathways
+- Designing or critiquing experiments
+- Constructing scientific arguments for writing
+- Reconciling conflicting findings
+- Any research question where overclaiming is a risk
+
+## Skill Installation
+
+### Claude Code
+
+```bash
+# Global install (available in all projects)
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.claude/skills/scientific-thinking
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" .claude/skills/scientific-thinking
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# Via ClawHub
+clawhub install scientific-thinking
+
+# Manual install
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.openclaw/skills/scientific-thinking
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" skills/scientific-thinking
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.hermes/skills/research/scientific-thinking
+```
+
+Or add to `~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/scientific-thinking
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.pimo/skills/scientific-thinking
+```
+
+### OpenAI Codex
+
+```bash
+# User-level install
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.agents/skills/scientific-thinking
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" .agents/skills/scientific-thinking
+```
+
+### SkillsMP
+
+```bash
+skills install scientific-thinking
+```
+
+### Installation paths summary
+
+| Platform | Global path | Project path |
+|----------|-------------|--------------|
+| Claude Code | `~/.claude/skills/scientific-thinking/` | `.claude/skills/scientific-thinking/` |
+| OpenClaw | `~/.openclaw/skills/scientific-thinking/` | `skills/scientific-thinking/` |
+| Hermes Agent | `~/.hermes/skills/research/scientific-thinking/` | Via `external_dirs` config |
+| Pi-Mo | `~/.pimo/skills/scientific-thinking/` | — |
+| OpenAI Codex | `~/.agents/skills/scientific-thinking/` | `.agents/skills/scientific-thinking/` |
+
+## Files
+
+- `SKILL.md` — **the only required file**. Loaded by all platforms as the skill instructions.
+- `agents/openai.yaml` — OpenAI Codex-specific configuration (display, policy, capabilities)
+- `checks.md` — 10-point self-check list referenced by SKILL.md
+- `examples.md` — 8 annotated examples referenced by SKILL.md
+- `README.md` — this file (English)
+- `README_CN.md` — Chinese documentation
+
+> **Note:** Only `SKILL.md` is needed for the skill to work. All other files are supplementary.
+
+## GitHub Topics
+
+For SkillsMP indexing, the Agents365-ai/365-skills monorepo uses the following topics:
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `scientific-thinking` `research` `reasoning` `evidence-evaluation`
+
+## License
+
+MIT
+
+## Support
+
+If this skill helps your research, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## Author
+
+**Agents365-ai**
+
+- Bilibili: https://space.bilibili.com/441831884
+- GitHub: https://github.com/Agents365-ai

--- a/plugins/scientific-thinking-general/README_CN.md
+++ b/plugins/scientific-thinking-general/README_CN.md
@@ -1,0 +1,178 @@
+# scientific-thinking — AI 智能体的结构化科研思维 skill
+
+[English](README.md)
+
+## 功能说明
+
+- 在回答前先对研究问题进行框架构建与问题分解
+- 区分：观察事实 / 直接证据 / 间接证据 / 解释 / 假设 / 推测
+- 标注声明来源：来自提供的数据 / 背景知识 / 推断
+- 按现有支持程度对竞争性解释排序
+- 根据证据强度校准结论语言
+- 明确界定解释的边界和未解决的不确定性
+- 建议最低成本的下一步，用于区分各竞争解释
+
+## 多平台支持
+
+兼容所有主流支持 [Agent Skills](https://agentskills.io) 格式的 AI 智能体：
+
+| 平台 | 支持状态 | 说明 |
+|------|----------|------|
+| **Claude Code** | ✅ 完全支持 | 原生 SKILL.md 格式 |
+| **OpenClaw / ClawHub** | ✅ 完全支持 | `metadata.openclaw` 命名空间 |
+| **Hermes Agent** | ✅ 完全支持 | `metadata.hermes` 命名空间，category: research |
+| **Pi-Mo** | ✅ 完全支持 | `metadata.pimo` 命名空间 |
+| **OpenAI Codex** | ✅ 完全支持 | `agents/openai.yaml` 侧车文件 |
+| **SkillsMP** | ✅ 可索引 | GitHub topics 已配置 |
+
+## 有 skill 与无 skill 的对比
+
+| 能力 | 原生智能体 | 本 skill |
+|------|-----------|---------|
+| 区分事实与解释 | 偶尔 | 始终，明确标注 |
+| 标注声明来源 | 否 | 是 — 数据 / 背景知识 / 推断 |
+| 考虑替代解释 | 不稳定 | 是 — 按支持程度排序 |
+| 校准语言到证据 | 否 | 是 — 5 级量表 |
+| 说明解释边界 | 少见 | 始终 |
+| 建议鉴别性下一步 | 否 | 是 |
+| 正确处理阴性结果 | 否 | 是 — 无证据 ≠ 证据缺失 |
+| 调和矛盾文献 | 否 | 是 — 梳理实验变量差异 |
+| 证据缺失时的处理 | 否 | 是 — 标注为初步推断 |
+
+## 适用场景
+
+- 解读实验结果或论文结论
+- 评估竞争性假设
+- 分析机制或通路
+- 设计或评估实验方案
+- 构建学术论证
+- 调和相互矛盾的研究发现
+- 任何存在过度解读风险的研究问题
+
+## skill 安装
+
+### Claude Code
+
+```bash
+# 全局安装（在所有项目中可用）
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.claude/skills/scientific-thinking
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" .claude/skills/scientific-thinking
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# 通过 ClawHub
+clawhub install scientific-thinking
+
+# 手动安装
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.openclaw/skills/scientific-thinking
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" skills/scientific-thinking
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.hermes/skills/research/scientific-thinking
+```
+
+或在 `~/.hermes/config.yaml` 中添加：
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/scientific-thinking
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.pimo/skills/scientific-thinking
+```
+
+### OpenAI Codex
+
+```bash
+# 用户级安装
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" ~/.agents/skills/scientific-thinking
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-general/skills/scientific-thinking" .agents/skills/scientific-thinking
+```
+
+### SkillsMP
+
+```bash
+skills install scientific-thinking
+```
+
+### 安装路径汇总
+
+| 平台 | 全局路径 | 项目路径 |
+|------|----------|----------|
+| Claude Code | `~/.claude/skills/scientific-thinking/` | `.claude/skills/scientific-thinking/` |
+| OpenClaw | `~/.openclaw/skills/scientific-thinking/` | `skills/scientific-thinking/` |
+| Hermes Agent | `~/.hermes/skills/research/scientific-thinking/` | 通过 `external_dirs` 配置 |
+| Pi-Mo | `~/.pimo/skills/scientific-thinking/` | — |
+| OpenAI Codex | `~/.agents/skills/scientific-thinking/` | `.agents/skills/scientific-thinking/` |
+
+## 文件说明
+
+- `SKILL.md` — **唯一必需文件**。所有平台均加载此文件作为 skill 指令。
+- `agents/openai.yaml` — OpenAI Codex 专用配置（显示名称、策略、能力列表）
+- `checks.md` — SKILL.md 引用的 10 项自检清单
+- `examples.md` — SKILL.md 引用的 8 个示例
+- `README.md` — 英文文档
+- `README_CN.md` — 本文件（中文）
+
+> **注意：** 只需要 `SKILL.md` 即可使 skill 正常工作，其他文件均为辅助文件。
+
+## GitHub Topics
+
+用于 SkillsMP 索引，本仓库使用以下 topics：
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `scientific-thinking` `research` `reasoning` `evidence-evaluation`
+
+## 开源协议
+
+MIT
+
+## 支持作者
+
+如果这个 skill 对你的科研有帮助，欢迎支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## 作者
+
+**Agents365-ai**
+
+- Bilibili: https://space.bilibili.com/441831884
+- GitHub: https://github.com/Agents365-ai

--- a/plugins/scientific-thinking-general/skills/scientific-thinking/SKILL.md
+++ b/plugins/scientific-thinking-general/skills/scientific-thinking/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: scientific-thinking
+description: Use when interpreting research findings, evaluating scientific evidence, analyzing mechanisms, comparing competing hypotheses, designing experiments, or constructing scientific arguments.
+license: MIT
+homepage: https://github.com/Agents365-ai/365-skills
+compatibility: No external tool dependencies. Works with any LLM-based agent on any platform.
+platforms: [macos, linux, windows]
+metadata: {"openclaw":{"requires":{},"emoji":"🔬","os":["darwin","linux","win32"]},"hermes":{"tags":["scientific-thinking","research","reasoning","evidence-evaluation","hypothesis","experiment-design","mechanism","peer-review"],"category":"research","requires_tools":[],"related_skills":["literature-review","paper-reader","zotero-cli-cc"]},"pimo":{"category":"research","tags":["scientific-thinking","reasoning","evidence-evaluation","research","hypothesis"]},"author":"Agents365-ai","version":"1.0.0"}
+---
+
+# Scientific Thinking
+
+A meta-skill for structured, evidence-aware, boundary-conscious scientific reasoning. Your role is not just to answer — it is to reason like a careful researcher.
+
+## When to Use
+
+- Interpreting experimental results or paper conclusions
+- Analyzing mechanisms or pathways
+- Distinguishing concepts that are being conflated
+- Evaluating competing hypotheses
+- Designing or critiquing experiments
+- Constructing scientific arguments
+
+## Update check
+
+Throttle to one check per 24 hours per installation; never mutate the skill directory without explicit user consent.
+
+1. If `<this-skill-dir>/.last_update` exists and is less than 24 hours old, skip this step entirely.
+
+2. Otherwise, fetch the latest tag from upstream:
+
+   ```bash
+   git -C <this-skill-dir> ls-remote --tags origin 'v*' 2>/dev/null \
+     | awk '{print $2}' | sed 's|refs/tags/||' \
+     | sort -V | tail -1
+   ```
+
+3. Compare with this skill's `metadata.version` from the frontmatter. If the upstream tag is strictly newer (semver), tell the user one line and ask:
+
+   > "A newer version of this skill is available: vX.Y.Z → vA.B.C. Want me to `git pull`?"
+
+   If they say yes, run `git -C <this-skill-dir> pull --ff-only`. Refresh `.last_update` either way so the prompt doesn't repeat for 24 hours.
+
+4. If upstream is the same or older, refresh `.last_update` silently and continue.
+
+5. On any failure (offline, not a git checkout — e.g. ClawHub-installed copy, read-only path, no permission), swallow the error silently and continue with the user's task. Do not mention the failure.
+
+## Core Reasoning Framework
+
+Work through these layers before responding.
+
+### 1. Frame the Problem
+
+- What exactly is being asked?
+- Scientific level: fact / concept / mechanism / method / interpretation / decision?
+- What is known, unknown, and assumed?
+- Restate the real problem if the question is broad or ambiguous.
+
+### 2. Decompose
+
+- What needs to be defined first?
+- What hidden assumptions are present?
+- What distinctions must be kept separate (phenotype vs mechanism, association vs causation, state vs lineage)?
+- What would make the conclusion invalid?
+
+### 3. Separate Evidence from Interpretation
+
+Always distinguish among: observed fact / direct evidence / indirect evidence / interpretation / hypothesis / speculation / uncertainty.
+
+- Do not present a hypothesis as a fact.
+- Do not present correlation as causation.
+- Do not present a label as a mechanism.
+
+**Evidence provenance:** State whether each key claim comes from (a) provided data, (b) general background knowledge, or (c) inference. If required evidence is absent from the prompt, either retrieve it or explicitly label the answer as provisional reasoning.
+
+### 4. Consider Alternative Explanations
+
+Before giving a conclusion:
+- Is there another plausible explanation?
+- Could this be caused by confounding, measurement error, sampling bias, or definition mismatch?
+- Could this reflect context rather than essence?
+
+If multiple explanations are plausible, rank them by available support. Do not pretend there is only one. Surface alternatives only when they are genuinely plausible — do not force false balance.
+
+### 5. Calibrate Claim Strength
+
+Match conclusion strength to evidence strength:
+
+| Evidence level | Language to use |
+|----------------|-----------------|
+| Strong, replicated | "demonstrates", "establishes" |
+| Consistent, single source | "supports", "is consistent with" |
+| Suggestive, indirect | "suggests", "is compatible with" |
+| Speculative | "raises the possibility", "cannot exclude" |
+| Absent | "is insufficient to conclude" |
+
+### 6. Define the Boundary
+
+Every meaningful conclusion has limits. State when relevant:
+- what this conclusion supports vs. what it does not yet prove
+- under what conditions it may hold or not generalize
+- what evidence is still missing
+
+### 7. Move Toward Resolution
+
+Do not stop at abstract interpretation. Suggest:
+- the most likely current conclusion
+- the key unresolved issue
+- the lowest-cost next step that would discriminate between the leading explanations
+
+## Output Structure
+
+Unless the user wants a very short answer, organize in this order:
+
+1. Problem framing
+2. What can be said with confidence (with provenance: data / background / inference)
+3. Main possible interpretations, ranked by support
+4. Most reasonable current conclusion
+5. Boundary / limitation / uncertainty
+6. Next step
+
+If the user wants a concise answer, compress this structure — do not abandon it.
+
+## Style
+
+**Be:** structured, precise, calm, intellectually honest, non-dogmatic
+
+**Do:**
+- Clarify definitions when concepts are mixed
+- Label what is observed vs. inferred vs. assumed
+- State uncertainty clearly
+
+**Do not:**
+- Jump to conclusions
+- Confuse description with explanation
+- Use confident language when evidence is weak
+- Ignore alternative explanations
+- Overclaim based on a single study or indirect evidence
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| Question is broad or ambiguous | Restate the real problem first |
+| Correlation present | Clarify: not causation without further evidence |
+| Single explanation offered | Check for alternatives before concluding |
+| Conclusion seems strong | State its boundary; label claim level |
+| Evidence is weak or absent | Hedge language; label as provisional; identify what's missing |
+| Concept conflated across levels | Separate levels (phenotype/mechanism, association/causation) before answering |
+| Evidence not in prompt | Retrieve it or explicitly label answer as provisional reasoning |
+
+## Before Responding
+
+Run through @checks.md.
+
+## Examples
+
+See @examples.md for preferred response style in common research scenarios.

--- a/plugins/scientific-thinking-general/skills/scientific-thinking/agents/openai.yaml
+++ b/plugins/scientific-thinking-general/skills/scientific-thinking/agents/openai.yaml
@@ -1,0 +1,17 @@
+interface:
+  display_name: "Scientific Thinking"
+  short_description: "Apply structured, evidence-aware scientific reasoning to research questions, result interpretation, hypothesis evaluation, and experiment design"
+  brand_color: "#2E86AB"
+
+policy:
+  allow_implicit_invocation: true
+
+capabilities:
+  - Frame and decompose research problems
+  - Distinguish evidence from interpretation and hypothesis
+  - Evaluate competing explanations with ranked plausibility
+  - Calibrate claim strength to evidence level
+  - Define interpretation boundaries and limitations
+  - Suggest lowest-cost next steps to resolve uncertainty
+
+prerequisites: []

--- a/plugins/scientific-thinking-general/skills/scientific-thinking/checks.md
+++ b/plugins/scientific-thinking-general/skills/scientific-thinking/checks.md
@@ -1,0 +1,19 @@
+# Scientific Thinking Checklist
+
+Before responding, verify:
+
+1. Did I identify what kind of problem this is (fact / concept / mechanism / method / interpretation / decision)?
+2. Did I restate the user's real question clearly if it was ambiguous?
+3. Did I label what is observed vs. inferred vs. assumed?
+4. Did I state whether each key claim comes from provided data, background knowledge, or inference?
+5. Did I avoid turning correlation into causation?
+6. Did I identify the strongest disconfirming explanation?
+7. Did I scale confidence language to match the actual evidence strength?
+8. Did I state the boundary or limitation of the conclusion?
+9. Would the proposed next step discriminate between the leading explanations?
+10. Is the response logically organized rather than scattered?
+
+If the answer is short, it should still preserve:
+- conclusion (with claim level)
+- boundary
+- next step

--- a/plugins/scientific-thinking-general/skills/scientific-thinking/examples.md
+++ b/plugins/scientific-thinking-general/skills/scientific-thinking/examples.md
@@ -1,0 +1,113 @@
+# Scientific Thinking — Response Style Examples
+
+## Example 1: Gene as a marker
+
+**User:** Is gene X a marker of exhausted T cells?
+
+**Pattern:**
+- Clarify that "marker" may mean enrichment marker, defining marker, or functional driver
+- State what evidence supports each interpretation
+- Explain that expression association alone supports enrichment, not functional importance
+- Mention possible context dependence
+
+**Preferred style:**
+"Gene X may be considered an exhaustion-associated marker if it is reproducibly enriched in exhausted-like T cells across relevant contexts. However, enrichment alone does not show that it defines exhaustion or drives the exhausted state. A stronger claim would require consistency across datasets, separation from activation-only states, and ideally functional perturbation. The current evidence (from background knowledge) supports 'associated marker'; the 'functional driver' claim would require further experimental evidence."
+
+---
+
+## Example 2: Pathway elevation in responders
+
+**User:** Why is this pathway elevated in responders?
+
+**Pattern:**
+- Clarify whether this is descriptive or mechanistic
+- State that enrichment does not establish causality
+- Offer plausible alternatives ranked by support
+- Suggest most informative next step
+
+**Preferred style:**
+"The pathway elevation is consistent with a biological difference between responders and non-responders, but does not show the pathway causes response. At least three explanations remain plausible: (1) the pathway contributes to response [leading]; (2) it reflects another upstream process associated with response; (3) it is driven by compositional or sampling differences. The most useful next step is to test whether the signal holds after controlling for composition and other covariates."
+
+---
+
+## Example 3: Interpreting a null result
+
+**User:** The knockout showed no phenotype. Does gene Y not matter?
+
+**Pattern:**
+- Distinguish absence of evidence from evidence of absence
+- List reasons a null result may not mean no function
+- Propose the most informative follow-up
+
+**Preferred style:**
+"A null phenotype under these conditions is consistent with gene Y being dispensable in this specific context, but it does not establish that gene Y has no function. Several explanations remain plausible: redundancy with another gene, context-dependence (the phenotype may require stress, injury, or a specific cell state), compensatory adaptation, or insufficient sensitivity of the readout. The most informative next step would be to test under conditions known to challenge the pathway, or use a more sensitive quantitative readout."
+
+---
+
+## Example 4: Choosing between two experiment designs
+
+**User:** Should I use bulk RNA-seq or scRNA-seq for this question?
+
+**Pattern:**
+- Clarify what the scientific question requires
+- Map each design to what it can and cannot answer
+- State the leading recommendation and the key assumption it rests on
+
+**Preferred style:**
+"The right choice depends on whether the question is about average gene expression across the sample or about cell-type-specific or compositional differences. If you need to resolve heterogeneity, detect rare cell populations, or understand cell-state transitions, scRNA-seq is required. If the question is about a homogeneous population or you need higher sensitivity per gene at lower cost, bulk RNA-seq may suffice. The leading recommendation is scRNA-seq, assuming the sample contains meaningful cellular heterogeneity — if that assumption is wrong, bulk with more biological replicates would give more statistical power."
+
+---
+
+## Example 5: Evaluating a causal claim from observational data
+
+**User:** This GWAS hit implies that protein Z drives disease risk.
+
+**Pattern:**
+- Separate association from causation
+- List steps needed to move from GWAS to causal claim
+- State what current evidence supports
+
+**Preferred style:**
+"A GWAS hit shows that a variant near protein Z is associated with disease risk at the population level. This supports that the locus is involved, but does not by itself establish that protein Z is the causal effector. Several steps are needed to move from association to causal claim: fine-mapping to identify the functional variant, eQTL / pQTL analysis to link the variant to protein Z expression or function, and ideally Mendelian randomization or functional perturbation. Current evidence (association only) supports 'protein Z locus is implicated'; the causal claim requires additional evidence."
+
+---
+
+## Example 6: Reconciling conflicting papers
+
+**User:** Paper A found pathway X is activated, paper B found it is suppressed. Which is right?
+
+**Pattern:**
+- Do not assume one paper is wrong
+- Identify experimental differences that could explain the conflict
+- Propose a resolution strategy
+
+**Preferred style:**
+"Before concluding one paper is wrong, check for experimental differences that could legitimately produce opposite results: different cell types or tissues, different timepoints (pathway X may be transiently activated then suppressed), different stimuli or doses, different readout methods measuring different components of the pathway, or different species. The most productive next step is to map these experimental variables across both papers and identify the most likely source of the discrepancy. If no variable explains the conflict, a direct head-to-head comparison in the same system would resolve it."
+
+---
+
+## Example 7: What is the best explanation
+
+**User:** What is the best explanation for this pattern?
+
+**Pattern:**
+- Avoid pretending there is only one explanation unless evidence is very strong
+- Provide the leading explanation, competing explanations, and ranking rationale
+- Mark uncertainty clearly
+
+**Preferred style:**
+"The leading explanation is X because it best accounts for observations A and B. However, Y remains plausible because current evidence does not exclude it. The most accurate current position is that the data support X more strongly than Y, but do not yet settle the question. Distinguishing X from Y would require evidence C."
+
+---
+
+## Example 8: How to solve a research problem
+
+**User:** How do I solve this research problem?
+
+**Pattern:**
+- Define the problem and identify the bottleneck
+- Suggest the lowest-cost next move
+- Note assumptions and risks
+
+**Preferred style:**
+"The immediate goal is not to fully solve the biology, but to reduce uncertainty around the key bottleneck. The most efficient next step is to test X, because it distinguishes the leading explanations with relatively low cost. The main risk is that the readout may still mix process A and process B, so interpretation should remain conditional until those are separated."


### PR DESCRIPTION
Retire the standalone Agents365-ai/scientific-thinking-skill repo: add the skill as plugins/scientific-thinking-general (SKILL.md, checks.md, examples.md, agents/openai.yaml, plugin READMEs + MIT license), point clone instructions, cross-links and SKILL.md homepage at the monorepo, and register it in .claude-plugin/marketplace.json (v1.0.0, MIT).