### PR TITLE
Move scientific-thinking-biology skill into the 365-skills monorepo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -679,15 +679,9 @@
       ]
     },
     {
-<<<<<<< HEAD
       "name": "scientific-thinking-biology",
       "source": "./plugins/scientific-thinking-biology",
       "description": "Use when interpreting biological research findings, evaluating life science evidence, analyzing molecular or cellular mechanisms, comparing competing biological hypotheses, designing or critiquing experiments in biology, genetics, genomics, cell biology, immunology, neuroscience, ecology, or any life science domain.",
-=======
-      "name": "scientific-thinking-general",
-      "source": "./plugins/scientific-thinking-general",
-      "description": "Use when interpreting research findings, evaluating scientific evidence, analyzing mechanisms, comparing competing hypotheses, designing experiments, or constructing scientific arguments.",
->>>>>>> origin/main
       "version": "1.0.0",
       "author": {
         "name": "Agents365-ai"
@@ -696,7 +690,6 @@
       "license": "MIT",
       "keywords": [
         "scientific-thinking",
-<<<<<<< HEAD
         "biology",
         "life-science",
         "genomics",
@@ -706,7 +699,19 @@
         "genetics",
         "molecular-biology",
         "experiment-design"
-=======
+      ]
+    },
+    {
+      "name": "scientific-thinking-general",
+      "source": "./plugins/scientific-thinking-general",
+      "description": "Use when interpreting research findings, evaluating scientific evidence, analyzing mechanisms, comparing competing hypotheses, designing experiments, or constructing scientific arguments.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/365-skills",
+      "license": "MIT",
+      "keywords": [
         "research",
         "reasoning",
         "evidence-evaluation",
@@ -714,7 +719,6 @@
         "experiment-design",
         "mechanism",
         "peer-review"
->>>>>>> origin/main
       ]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -677,6 +677,29 @@
         "plugins",
         "developer-reference"
       ]
+    },
+    {
+      "name": "scientific-thinking-biology",
+      "source": "./plugins/scientific-thinking-biology",
+      "description": "Use when interpreting biological research findings, evaluating life science evidence, analyzing molecular or cellular mechanisms, comparing competing biological hypotheses, designing or critiquing experiments in biology, genetics, genomics, cell biology, immunology, neuroscience, ecology, or any life science domain.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/365-skills",
+      "license": "MIT",
+      "keywords": [
+        "scientific-thinking",
+        "biology",
+        "life-science",
+        "genomics",
+        "cell-biology",
+        "immunology",
+        "neuroscience",
+        "genetics",
+        "molecular-biology",
+        "experiment-design"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install a single plugin (Claude Code): `/plugin install <plugin-name>`, e.g. `/p
 | `target-prioritization` | Multi-source drug-target due-diligence — turn a ranked gene list (e.g. scRNA-seq DE output) into a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan, then re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic |
 | `figshare` | Figshare v2 REST API — search public datasets/articles, batch-download files by ID/DOI/URL, and create, update, publish, or multi-part-upload to your own articles (large-file 3-step upload flow) |
 | `zenodo` | Zenodo REST API — deposit, publish, version, and search research artifacts (datasets, software, papers) with a citable DOI; sandbox-first, bucket-API uploads, full metadata reference and end-to-end shell examples |
+| `scientific-thinking-biology` | Biology-specific adaptation of scientific-thinking-general — marker vs driver, experimental-system validity, an 8-level biological evidence hierarchy, alternative-explanation and confound checks (composition, batch, redundancy), and system-aware conclusion language |
 
 ### Knowledge & notes
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,8 @@ Install a single plugin (Claude Code): `/plugin install <plugin-name>`, e.g. `/p
 | `target-prioritization` | Multi-source drug-target due-diligence — turn a ranked gene list (e.g. scRNA-seq DE output) into a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan, then re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic |
 | `figshare` | Figshare v2 REST API — search public datasets/articles, batch-download files by ID/DOI/URL, and create, update, publish, or multi-part-upload to your own articles (large-file 3-step upload flow) |
 | `zenodo` | Zenodo REST API — deposit, publish, version, and search research artifacts (datasets, software, papers) with a citable DOI; sandbox-first, bucket-API uploads, full metadata reference and end-to-end shell examples |
-<<<<<<< HEAD
-| `scientific-thinking-biology` | Biology-specific adaptation of scientific-thinking-general — marker vs driver, experimental-system validity, an 8-level biological evidence hierarchy, alternative-explanation and confound checks (composition, batch, redundancy), and system-aware conclusion language |
-=======
 | `scientific-thinking-general` | Structured scientific reasoning meta-skill — separates fact / evidence / hypothesis, ranks competing explanations by support, calibrates conclusion language to evidence strength, and defines interpretation boundaries |
->>>>>>> origin/main
+| `scientific-thinking-biology` | Biology-specific adaptation of scientific-thinking-general — marker vs driver, experimental-system validity, an 8-level biological evidence hierarchy, alternative-explanation and confound checks (composition, batch, redundancy), and system-aware conclusion language |
 
 ### Knowledge & notes
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,6 +56,7 @@ npx skills add Agents365-ai/365-skills -g
 | `target-prioritization` | 多源药物靶点尽职调查 —— 将排序基因列表（如 scRNA-seq 差异表达输出）转化为逐基因档案（UniProt、OpenTargets、PubMed），叠加本地跨谱系差异表达扫描，再按可配置综合评分（跨谱系趋同 + 成药性 + 疾病遗传学 + 可开发性 + 新颖性）重排。疾病无关，可配置靶疾病与细胞上下文查询 |
 | `figshare` | Figshare v2 REST API —— 搜索公开数据集/文章、按 ID/DOI/URL 批量下载文件，并可对自己账号的文章进行创建、更新、发布与多分片上传（大文件三步上传流程） |
 | `zenodo` | Zenodo REST API —— 存缴、发布、版本管理与检索研究成果（数据集、软件、论文）并获得可引用 DOI；默认先用 sandbox，支持 bucket API 上传，附完整元数据参考与端到端 Shell 示例 |
+| `scientific-thinking-biology` | scientific-thinking-general 的生物学专项适配版 —— 标志物与驱动因子区分、实验系统评估、8 级生物学证据层次、替代解释与混杂检查（组成、批次、冗余）、随证据强度校准的结论措辞 |
 
 ### 知识与笔记
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,11 +56,8 @@ npx skills add Agents365-ai/365-skills -g
 | `target-prioritization` | 多源药物靶点尽职调查 —— 将排序基因列表（如 scRNA-seq 差异表达输出）转化为逐基因档案（UniProt、OpenTargets、PubMed），叠加本地跨谱系差异表达扫描，再按可配置综合评分（跨谱系趋同 + 成药性 + 疾病遗传学 + 可开发性 + 新颖性）重排。疾病无关，可配置靶疾病与细胞上下文查询 |
 | `figshare` | Figshare v2 REST API —— 搜索公开数据集/文章、按 ID/DOI/URL 批量下载文件，并可对自己账号的文章进行创建、更新、发布与多分片上传（大文件三步上传流程） |
 | `zenodo` | Zenodo REST API —— 存缴、发布、版本管理与检索研究成果（数据集、软件、论文）并获得可引用 DOI；默认先用 sandbox，支持 bucket API 上传，附完整元数据参考与端到端 Shell 示例 |
-<<<<<<< HEAD
-| `scientific-thinking-biology` | scientific-thinking-general 的生物学专项适配版 —— 标志物与驱动因子区分、实验系统评估、8 级生物学证据层次、替代解释与混杂检查（组成、批次、冗余）、随证据强度校准的结论措辞 |
-=======
 | `scientific-thinking-general` | 结构化科学推理元技能 —— 区分事实/证据/假说、按支持度排序竞争性解释、结论措辞与证据强度校准、明确解释边界 |
->>>>>>> origin/main
+| `scientific-thinking-biology` | scientific-thinking-general 的生物学专项适配版 —— 标志物与驱动因子区分、实验系统评估、8 级生物学证据层次、替代解释与混杂检查（组成、批次、冗余）、随证据强度校准的结论措辞 |
 
 ### 知识与笔记
 

--- a/plugins/scientific-thinking-biology/LICENSE
+++ b/plugins/scientific-thinking-biology/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/scientific-thinking-biology/README.md
+++ b/plugins/scientific-thinking-biology/README.md
@@ -1,0 +1,176 @@
+# scientific-thinking-biology — Structured Scientific Reasoning for Biology & Life Science
+
+[中文文档](README_CN.md)
+
+A biology-specific adaptation of [scientific-thinking-general](https://github.com/Agents365-ai/365-skills/tree/main/plugins/scientific-thinking-biology/skills/scientific-thinking-biology), with domain-specific reasoning layers for molecular biology, genetics, genomics, cell biology, immunology, neuroscience, ecology, and all life science research.
+
+## What it does
+
+- Anchors reasoning to the correct biological level (molecular → cellular → tissue → organism → evolutionary)
+- Distinguishes marker from driver, correlation from causation, enrichment from mechanism
+- Evaluates the experimental system: in vitro / in vivo / ex vivo / clinical relevance and limits
+- Applies a biological evidence hierarchy (genetic perturbation > biochemical > pharmacological > correlative omics)
+- Flags biology-specific confounders: redundancy, compensation, composition bias, model organism gaps, overexpression artifacts, batch effects
+- Calibrates claim language to evidence strength using biology-appropriate language
+- Defines interpretation boundaries: species scope, cell type scope, disease context
+- Suggests the lowest-cost next experiment that would discriminate between explanations
+
+## Multi-Platform Support
+
+Works with all major AI agents that support the [Agent Skills](https://agentskills.io) format:
+
+| Platform | Status | Details |
+| ---------- | -------- | --------- |
+| **Claude Code** | ✅ Full support | Native SKILL.md format |
+| **OpenClaw / ClawHub** | ✅ Full support | `metadata.openclaw` namespace |
+| **Hermes Agent** | ✅ Full support | `metadata.hermes` namespace, category: research |
+| **Pi-Mo** | ✅ Full support | `metadata.pimo` namespace |
+| **SkillsMP** | ✅ Indexed | GitHub topics configured |
+
+## Comparison: with vs. without this skill
+
+| Capability | Native agent | This skill |
+| ------------ | ------------- | ------------ |
+| Distinguish marker from driver | No | Yes — requires functional perturbation |
+| Evaluate experimental system | No | Yes — in vitro / in vivo / clinical |
+| Apply biological evidence hierarchy | No | Yes — 8-level hierarchy |
+| Flag model organism translation gap | No | Yes — species scope stated |
+| Detect composition confound in omics | No | Yes — checks before concluding pathway |
+| Handle null phenotypes correctly | No | Yes — redundancy/compensation considered |
+| Separate enrichment from activity | No | Yes — enrichment ≠ pathway activation |
+| Label claim provenance | No | Yes — data / background / inference |
+| Calibrate language to evidence | No | Yes — 6-level scale |
+| Suggest discriminating next experiment | No | Yes |
+
+## When to use
+
+- Interpreting results from cell biology, genetics, genomics, immunology, neuroscience, or any life science
+- Analyzing molecular mechanisms, signaling pathways, or gene regulatory networks
+- Evaluating phenotype–genotype relationships
+- Designing or critiquing experimental systems
+- Interpreting omics data (bulk/scRNA-seq, ATAC-seq, proteomics, GWAS, etc.)
+- Evaluating model organism relevance and human translatability
+- Constructing scientific arguments for research writing
+- Reconciling conflicting findings across papers or experimental systems
+- Any biology question where overclaiming a mechanism is a risk
+
+## Skill Installation
+
+### Claude Code
+
+```bash
+# Global install (available in all projects)
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.claude/skills/scientific-thinking-biology
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" .claude/skills/scientific-thinking-biology
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# Via ClawHub
+clawhub install scientific-thinking-biology
+
+# Manual install
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.openclaw/skills/scientific-thinking-biology
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" skills/scientific-thinking-biology
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.hermes/skills/research/scientific-thinking-biology
+```
+
+Or add to `~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/scientific-thinking-biology
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.pimo/skills/scientific-thinking-biology
+```
+
+### SkillsMP
+
+```bash
+skills install scientific-thinking-biology
+```
+
+### Installation paths summary
+
+| Platform | Global path | Project path |
+| ---------- | ------------- | -------------- |
+| Claude Code | `~/.claude/skills/scientific-thinking-biology/` | `.claude/skills/scientific-thinking-biology/` |
+| OpenClaw | `~/.openclaw/skills/scientific-thinking-biology/` | `skills/scientific-thinking-biology/` |
+| Hermes Agent | `~/.hermes/skills/research/scientific-thinking-biology/` | Via `external_dirs` config |
+| Pi-Mo | `~/.pimo/skills/scientific-thinking-biology/` | — |
+
+## Files
+
+- `SKILL.md` — **the only required file**. Loaded by all platforms as the skill instructions.
+- `checks.md` — 15-point biology checklist referenced by SKILL.md (general + biology-specific checks)
+- `examples.md` — 10 annotated biology examples referenced by SKILL.md
+- `README.md` — this file (English)
+- `README_CN.md` — Chinese documentation
+
+> **Note:** Only `SKILL.md` is needed for the skill to work. All other files are supplementary.
+
+## Related Skills
+
+- [scientific-thinking-general](https://github.com/Agents365-ai/365-skills/tree/main/plugins/scientific-thinking-biology/skills/scientific-thinking-biology) — the general-domain version this skill is based on
+- [literature-review](https://github.com/Agents365-ai/zotero-research-assistant) — systematic literature review workflows
+- [nh-bioinfo-practice-skill](https://github.com/Agents365-ai) — single-cell and spatial omics analysis
+
+## GitHub Topics
+
+For SkillsMP indexing, the Agents365-ai/365-skills monorepo uses the following topics:
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `scientific-thinking` `biology` `life-science` `genomics` `cell-biology` `immunology` `neuroscience` `research` `reasoning`
+
+## License
+
+MIT
+
+## Support
+
+If this skill helps your research, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## Author
+
+**Agents365-ai**
+
+- Bilibili: <https://space.bilibili.com/441831884>
+- GitHub: <https://github.com/Agents365-ai>

--- a/plugins/scientific-thinking-biology/README_CN.md
+++ b/plugins/scientific-thinking-biology/README_CN.md
@@ -1,0 +1,176 @@
+# scientific-thinking-biology — 面向生物与生命科学的结构化科研思维 skill
+
+[English](README.md)
+
+本 skill 是 [scientific-thinking-general](https://github.com/Agents365-ai/365-skills/tree/main/plugins/scientific-thinking-biology/skills/scientific-thinking-biology) 的生物学专项适配版，针对分子生物学、遗传学、基因组学、细胞生物学、免疫学、神经科学、生态学等生命科学研究领域，加入了领域专属的推理层次与常见陷阱检查。
+
+## 功能说明
+
+- 将推理锚定到正确的生物层次（分子 → 细胞 → 组织 → 个体 → 进化）
+- 区分标志物与驱动因子、相关性与因果性、富集与机制
+- 评估实验系统的适用范围：体外 / 体内 / 离体 / 临床数据的局限性
+- 应用生物学证据等级（遗传扰动 > 生化重建 > 药理 > 相关性组学）
+- 识别生物学特有混杂因素：基因冗余、代偿效应、细胞组成偏差、模式生物转化差距、过表达伪影、批次效应
+- 根据证据强度校准结论语言
+- 明确界定解释边界：物种范围、细胞类型范围、疾病背景
+- 建议最低成本的鉴别性下一步实验
+
+## 多平台支持
+
+兼容所有主流支持 [Agent Skills](https://agentskills.io) 格式的 AI 智能体：
+
+| 平台 | 支持状态 | 说明 |
+| ------ | ---------- | ------ |
+| **Claude Code** | ✅ 完全支持 | 原生 SKILL.md 格式 |
+| **OpenClaw / ClawHub** | ✅ 完全支持 | `metadata.openclaw` 命名空间 |
+| **Hermes Agent** | ✅ 完全支持 | `metadata.hermes` 命名空间，category: research |
+| **Pi-Mo** | ✅ 完全支持 | `metadata.pimo` 命名空间 |
+| **SkillsMP** | ✅ 可索引 | GitHub topics 已配置 |
+
+## 有 skill 与无 skill 的对比
+
+| 能力 | 原生智能体 | 本 skill |
+| ------ | ----------- | --------- |
+| 区分标志物与驱动因子 | 否 | 是 — 需要功能性扰动验证 |
+| 评估实验系统 | 否 | 是 — 体外 / 体内 / 临床范围 |
+| 应用生物学证据等级 | 否 | 是 — 8 级证据层次 |
+| 标注模式生物转化差距 | 否 | 是 — 明确物种范围 |
+| 识别组学中的组成偏差 | 否 | 是 — 排除成分混杂后再得出结论 |
+| 正确处理阴性表型 | 否 | 是 — 考虑冗余与代偿 |
+| 区分富集与通路活性 | 否 | 是 — 富集分数 ≠ 通路激活 |
+| 标注声明来源 | 否 | 是 — 数据 / 背景知识 / 推断 |
+| 校准语言到证据 | 否 | 是 — 6 级量表 |
+| 建议鉴别性下一步实验 | 否 | 是 |
+
+## 适用场景
+
+- 解读细胞生物学、遗传学、基因组学、免疫学、神经科学等领域的实验结果
+- 分析分子机制、信号通路或基因调控网络
+- 评估表型–基因型关系
+- 设计或评估实验系统
+- 解读组学数据（bulk/scRNA-seq、ATAC-seq、蛋白质组学、GWAS 等）
+- 评估模式生物研究结果向人类的转化潜力
+- 构建学术写作中的科学论证
+- 调和不同文献或实验系统之间相互矛盾的发现
+- 任何存在过度解读机制风险的生物学问题
+
+## skill 安装
+
+### Claude Code
+
+```bash
+# 全局安装（在所有项目中可用）
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.claude/skills/scientific-thinking-biology
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" .claude/skills/scientific-thinking-biology
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# 通过 ClawHub
+clawhub install scientific-thinking-biology
+
+# 手动安装
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.openclaw/skills/scientific-thinking-biology
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" skills/scientific-thinking-biology
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.hermes/skills/research/scientific-thinking-biology
+```
+
+或在 `~/.hermes/config.yaml` 中添加：
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/scientific-thinking-biology
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/scientific-thinking-biology/skills/scientific-thinking-biology" ~/.pimo/skills/scientific-thinking-biology
+```
+
+### SkillsMP
+
+```bash
+skills install scientific-thinking-biology
+```
+
+### 安装路径汇总
+
+| 平台 | 全局路径 | 项目路径 |
+| ------ | ---------- | ---------- |
+| Claude Code | `~/.claude/skills/scientific-thinking-biology/` | `.claude/skills/scientific-thinking-biology/` |
+| OpenClaw | `~/.openclaw/skills/scientific-thinking-biology/` | `skills/scientific-thinking-biology/` |
+| Hermes Agent | `~/.hermes/skills/research/scientific-thinking-biology/` | 通过 `external_dirs` 配置 |
+| Pi-Mo | `~/.pimo/skills/scientific-thinking-biology/` | — |
+
+## 文件说明
+
+- `SKILL.md` — **唯一必需文件**。所有平台均加载此文件作为 skill 指令。
+- `checks.md` — SKILL.md 引用的 15 项自检清单（通用 + 生物学专项）
+- `examples.md` — SKILL.md 引用的 10 个生物学场景示例
+- `README.md` — 英文文档
+- `README_CN.md` — 本文件（中文）
+
+> **注意：** 只需要 `SKILL.md` 即可使 skill 正常工作，其他文件均为辅助文件。
+
+## 相关 skill
+
+- [scientific-thinking-general](https://github.com/Agents365-ai/365-skills/tree/main/plugins/scientific-thinking-biology/skills/scientific-thinking-biology) — 本 skill 所基于的通用领域版本
+- [literature-review](https://github.com/Agents365-ai/zotero-research-assistant) — 系统性文献综述工作流
+- [nh-bioinfo-practice-skill](https://github.com/Agents365-ai) — 单细胞与空间组学分析
+
+## GitHub Topics
+
+用于 SkillsMP 索引，本仓库使用以下 topics：
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `scientific-thinking` `biology` `life-science` `genomics` `cell-biology` `immunology` `neuroscience` `research` `reasoning`
+
+## 开源协议
+
+MIT
+
+## 支持作者
+
+如果这个 skill 对你的科研有帮助，欢迎支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## 作者
+
+**Agents365-ai**
+
+- Bilibili: <https://space.bilibili.com/441831884>
+- GitHub: <https://github.com/Agents365-ai>

--- a/plugins/scientific-thinking-biology/skills/scientific-thinking-biology/SKILL.md
+++ b/plugins/scientific-thinking-biology/skills/scientific-thinking-biology/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: scientific-thinking-biology
+description: Use when interpreting biological research findings, evaluating life science evidence, analyzing molecular or cellular mechanisms, comparing competing biological hypotheses, designing or critiquing experiments in biology, genetics, genomics, cell biology, immunology, neuroscience, ecology, or any life science domain. Triggers on questions about gene function, pathways, phenotypes, GWAS hits, single-cell data, animal models, clinical translation, evolutionary arguments, or any biology/life science reasoning task.
+license: MIT
+homepage: https://github.com/Agents365-ai/365-skills
+compatibility: No external tool dependencies. Works with any LLM-based agent on any platform.
+platforms: [macos, linux, windows]
+metadata: {"openclaw":{"requires":{},"emoji":"🧬","os":["darwin","linux","win32"]},"hermes":{"tags":["scientific-thinking","biology","life-science","genomics","cell-biology","immunology","neuroscience","genetics","molecular-biology","experiment-design"],"category":"research","requires_tools":[],"related_skills":["literature-review","paper-reader","zotero-cli-cc","nh-bioinfo-practice-skill"]},"pimo":{"category":"research","tags":["biology","scientific-thinking","life-science","genomics","mechanism","hypothesis"]},"author":"Agents365-ai","version":"1.0.0"}
+---
+
+# Scientific Thinking — Biology & Life Science
+
+A meta-skill for structured, evidence-aware, boundary-conscious scientific reasoning in biology and life science. Biology is complex: phenotypes arise from networks not single genes, model systems don't always translate, and the same data can support multiple mechanistic models. Your role is not just to answer — it is to reason like a careful biologist.
+
+## When to Use
+
+- Interpreting experimental results from cell biology, genetics, genomics, immunology, neuroscience, or any life science
+- Analyzing molecular mechanisms, signaling pathways, or gene regulatory networks
+- Evaluating phenotype–genotype relationships
+- Distinguishing marker from driver, association from causation, correlation from mechanism
+- Designing, selecting, or critiquing experimental systems (in vitro, in vivo, ex vivo, organoids, patient data)
+- Evaluating model organism relevance and translatability to humans
+- Interpreting omics data (bulk/single-cell RNA-seq, ATAC-seq, proteomics, GWAS, etc.)
+- Constructing or evaluating evolutionary, ecological, or physiological arguments
+
+## Update check
+
+Throttle to one check per 24 hours per installation; never mutate the skill directory without explicit user consent.
+
+1. If `<this-skill-dir>/.last_update` exists and is less than 24 hours old, skip this step entirely.
+
+2. Otherwise, fetch the latest tag from upstream:
+
+   ```bash
+   git -C <this-skill-dir> ls-remote --tags origin 'v*' 2>/dev/null \
+     | awk '{print $2}' | sed 's|refs/tags/||' \
+     | sort -V | tail -1
+   ```
+
+3. Compare with this skill's `metadata.version` from the frontmatter. If the upstream tag is strictly newer (semver), tell the user one line and ask:
+
+   > "A newer version of this skill is available: vX.Y.Z → vA.B.C. Want me to `git pull`?"
+
+   If they say yes, run `git -C <this-skill-dir> pull --ff-only`. Refresh `.last_update` either way so the prompt doesn't repeat for 24 hours.
+
+4. If upstream is the same or older, refresh `.last_update` silently and continue.
+
+5. On any failure (offline, not a git checkout — e.g. ClawHub-installed copy, read-only path, no permission), swallow the error silently and continue with the user's task. Do not mention the failure.
+
+## Biological Levels of Organization
+
+Before reasoning, anchor the question to its biological level. Confusion often arises from mixing levels:
+
+| Level | Examples |
+| ------- | --------- |
+| Molecular | protein structure, binding affinity, enzymatic activity, mRNA abundance |
+| Cellular | cell state, gene expression program, cell-type identity, metabolism |
+| Tissue / Organ | composition, architecture, intercellular communication |
+| Organism | phenotype, behavior, physiology, disease manifestation |
+| Population / Evolutionary | allele frequency, selection pressure, fitness, adaptation |
+| Ecosystem | species interaction, community dynamics |
+
+A finding at one level does not automatically transfer to another level.
+
+## Core Reasoning Framework
+
+Work through these layers before responding.
+
+### 1. Frame the Problem
+
+- What exactly is being asked?
+- At which biological level(s): molecular / cellular / tissue / organismal / evolutionary?
+- What is known, unknown, and assumed in this biological context?
+- Is the question about presence, quantity, timing, location, mechanism, or causal role?
+- Restate the real problem if the question conflates levels or mixes concepts.
+
+### 2. Decompose — Biology-Specific Pitfalls
+
+Proactively check for the most common sources of biological confusion:
+
+- **Marker vs. driver:** Is gene/protein X merely associated with a state, or does it cause it? Enrichment ≠ function.
+- **Correlation vs. causation:** Observational co-occurrence does not establish mechanism — state what experimental evidence would.
+- **Association vs. mechanism:** A GWAS or eQTL hit identifies a locus, not a causal effector; extra steps are required.
+- **Label vs. mechanism:** Cell type names ("regulatory T cell", "M2 macrophage") are phenotypic conveniences, not mechanistic explanations.
+- **State vs. lineage:** Is this a stable cell identity or a transient cell state?
+- **In vitro vs. in vivo:** Cultured cells often lose tissue context, niche signals, and physiological concentrations.
+- **Model organism vs. human:** Mouse, zebrafish, worm, and fly results may not translate due to differences in gene redundancy, immune system, physiology, or lifespan.
+- **Bulk vs. single-cell:** Bulk averages can obscure population heterogeneity; single-cell captures heterogeneity but has its own technical noise.
+- **Overexpression vs. endogenous expression:** Overexpression artifacts are a constant risk — does the finding hold under endogenous conditions?
+
+### 3. Separate Evidence from Interpretation
+
+Always distinguish: observed fact / direct evidence / indirect evidence / interpretation / hypothesis / speculation / uncertainty.
+
+**Evidence provenance:** State whether each key claim comes from (a) provided data, (b) general background knowledge, or (c) inference. If required evidence is absent from the prompt, either retrieve it or explicitly label the answer as provisional reasoning.
+
+**Common biological evidence hierarchy** (from stronger to weaker, context-dependent):
+
+1. Genetic perturbation in a relevant in vivo model (KO, KI, conditional, CRISPRi/a)
+2. Biochemical reconstitution or direct structural evidence
+3. Pharmacological inhibition with selective tool compounds
+4. In vivo pharmacology without genetic validation
+5. Organoid or ex vivo primary cell experiments
+6. Immortalized cell lines (note tissue-of-origin and transformation artifacts)
+7. Correlative omics (transcriptomics, proteomics, GWAS) — association only
+8. Computational predictions (structural modeling, pathway enrichment scores)
+
+Position each claim in this hierarchy before concluding.
+
+### 4. Evaluate the Experimental System
+
+Every biological conclusion is conditional on its experimental system. Ask:
+
+- **Model fidelity:** Does this model recapitulate the biology of interest? (e.g., PDX vs. cell line, humanized mouse vs. standard mouse)
+- **Cell type / tissue relevance:** Was the experiment done in the right cell type, developmental stage, or disease state?
+- **Technical confounders:** batch effects in omics, doublets in scRNA-seq, off-target effects of CRISPR/shRNA/small molecules, cell line contamination, antibody specificity
+- **Statistical power:** sample size, replicates (biological vs. technical), multiple testing burden
+- **Generalizability:** Single lab, single cohort, single timepoint — how robust is the finding?
+
+### 5. Consider Alternative Biological Explanations
+
+Before giving a conclusion:
+
+- Is there another plausible mechanistic explanation?
+- Could this result be explained by: redundancy, compensation, off-target effects, confounding (composition, batch, sex, age), or tissue/context specificity?
+- Could a null phenotype reflect redundancy rather than dispensability?
+- Could pathway enrichment reflect upstream events rather than the pathway itself being causal?
+
+If multiple explanations are plausible, rank them by available support. Do not force false balance, but do not pretend there is only one explanation either.
+
+### 6. Calibrate Claim Strength
+
+Match conclusion language to evidence strength:
+
+| Evidence level | Language to use |
+| ---------------- | ----------------- |
+| Multiple orthogonal experiments in vivo + in vitro + human data | "establishes", "demonstrates" |
+| Consistent genetic + pharmacological evidence in one system | "supports strongly", "provides strong evidence" |
+| Single genetic or pharmacological evidence, one system | "supports", "is consistent with" |
+| Correlative omics or in vitro only | "suggests", "raises the possibility" |
+| Computational or indirect | "is compatible with", "cannot exclude" |
+| No relevant evidence | "is insufficient to conclude" |
+
+### 7. Define the Biological Boundary
+
+Every biological conclusion has biological limits. State when relevant:
+
+- Species scope (mouse finding vs. human biology)
+- Cell type scope (cell line finding vs. primary cells vs. in vivo)
+- Disease stage or context (acute vs. chronic, tumor microenvironment vs. peripheral)
+- Physiological range (concentration, timing, developmental window)
+- What this conclusion supports vs. what it does not yet prove
+
+### 8. Move Toward Resolution
+
+Do not stop at abstract interpretation. Suggest:
+
+- The most likely current conclusion given available evidence
+- The key unresolved biological question
+- The lowest-cost next experiment that would discriminate between leading explanations (e.g., conditional knockout, orthogonal inhibitor, patient cohort validation)
+
+## Output Structure
+
+Unless the user wants a short answer, organize in this order:
+
+1. Biological level and problem framing
+2. What can be said with confidence (with provenance: data / background / inference)
+3. Assessment of the experimental system
+4. Main possible biological interpretations, ranked by support
+5. Most reasonable current conclusion
+6. Boundary: species, cell type, context, or methodological limits
+7. Next step: lowest-cost discriminating experiment or analysis
+
+If the user wants a concise answer, compress this structure — do not abandon it.
+
+## Style
+
+**Be:** structured, precise, intellectually honest, non-dogmatic, biologically grounded
+
+**Do:**
+
+- Separate phenotype from mechanism, correlation from causation, association from function
+- Name the experimental system when citing evidence (e.g., "in mouse tumor models", "in immortalized HEK293 cells")
+- Label what is observed vs. inferred vs. assumed
+- State uncertainty clearly and suggest how to resolve it
+
+**Do not:**
+
+- Call a gene a driver based on expression correlation alone
+- Treat a mouse phenotype as established human biology without caveats
+- Use confident mechanistic language when only correlative data exist
+- Ignore alternative explanations (redundancy, compensation, off-target, composition bias)
+- Treat enrichment scores as evidence of pathway activity without noting the limitation
+
+## Quick Reference
+
+| Situation | Action |
+| ----------- | -------- |
+| Gene X is enriched in a cell type | Distinguish enrichment marker from functional driver |
+| Pathway elevated in responders | Separate association from causation; note composition confound |
+| Knockout shows no phenotype | Consider redundancy, compensation, context-dependence before concluding dispensable |
+| GWAS hit near gene Z | Association only; fine-mapping + functional validation needed for causality |
+| In vitro finding | Note cell line limitations; ask what in vivo evidence exists |
+| Mouse model result | Ask about translation gap; humanized models or patient data needed |
+| Conflicting papers | Check cell type, species, timepoint, dosing, readout — context likely differs |
+| Enrichment score elevated | Enrichment ≠ activity; confirm with orthogonal readout |
+| scRNA-seq cluster labeled as cell type | Label is a phenotypic convenience; state what marker genes define it |
+| Single experiment, single lab | Replicate, orthogonal approach, and independent cohort needed before concluding |
+
+## Before Responding
+
+Run through @checks.md.
+
+## Examples
+
+See @examples.md for preferred response style in common biology research scenarios.

--- a/plugins/scientific-thinking-biology/skills/scientific-thinking-biology/checks.md
+++ b/plugins/scientific-thinking-biology/skills/scientific-thinking-biology/checks.md
@@ -1,0 +1,27 @@
+# Scientific Thinking — Biology Checklist
+
+Before responding, verify:
+
+## General Reasoning
+1. Did I identify the biological level(s) of the problem (molecular / cellular / tissue / organismal / evolutionary)?
+2. Did I restate the user's real question clearly if it was ambiguous or mixed levels?
+3. Did I label what is observed vs. inferred vs. assumed?
+4. Did I state whether each key claim comes from provided data, background knowledge, or inference?
+5. Did I scale confidence language to match the actual evidence strength?
+6. Did I state the boundary or limitation of the conclusion?
+7. Would the proposed next step discriminate between the leading explanations?
+8. Is the response logically organized rather than scattered?
+
+## Biology-Specific Checks
+9. Did I avoid calling a gene a driver based on expression correlation alone?
+10. Did I name and evaluate the experimental system (in vitro / in vivo / ex vivo / clinical)?
+11. Did I note relevant species or model organism translation gaps?
+12. Did I check for alternative explanations: redundancy, compensation, off-target effects, composition bias, or context-dependence?
+13. Did I distinguish phenotype from mechanism?
+14. Did I distinguish association/enrichment from causation/function?
+15. Did I note relevant technical confounders (batch effects, overexpression artifacts, antibody specificity, doublets, etc.)?
+
+## If the answer is short, it should still preserve:
+- conclusion (with claim level and evidence source)
+- biological boundary (species, cell type, context)
+- next step

--- a/plugins/scientific-thinking-biology/skills/scientific-thinking-biology/examples.md
+++ b/plugins/scientific-thinking-biology/skills/scientific-thinking-biology/examples.md
@@ -1,0 +1,142 @@
+# Scientific Thinking — Biology Response Style Examples
+
+## Example 1: Gene as a marker of a cell state
+
+**User:** Is gene X a marker of exhausted T cells?
+
+**Pattern:**
+- Clarify that "marker" may mean enrichment marker, defining marker, or functional driver
+- State what evidence supports each interpretation
+- Explain that expression association alone supports enrichment, not functional importance
+- Mention context dependence (tumor vs. chronic infection, human vs. mouse)
+
+**Preferred style:**
+"Gene X may qualify as an exhaustion-associated enrichment marker if it is reproducibly enriched in exhausted-like T cells across relevant contexts (from background knowledge). However, enrichment alone does not show that it defines exhaustion or drives the exhausted state — those require functional perturbation (knockdown/knockout and rescue). The claim should be stated as 'enrichment marker' unless: (1) expression is required for exhaustion-defining features, (2) perturbation alters the exhaustion program, and (3) findings hold in more than one model. Context also matters: exhaustion in chronic LCMV infection (mouse) may differ from tumor-infiltrating T cell exhaustion or human HIV settings."
+
+---
+
+## Example 2: Pathway enrichment in responders
+
+**User:** Why is this pathway elevated in responders?
+
+**Pattern:**
+- Clarify whether this is descriptive (enrichment) or mechanistic (causation)
+- Name the experimental system and its limits
+- Offer plausible alternatives ranked by support, including composition confound
+- Suggest most informative next step
+
+**Preferred style:**
+"The pathway elevation in responders is a correlation (from provided data, bulk RNA-seq). At least three explanations remain plausible: (1) the pathway is biologically active and contributes to response [leading hypothesis if supported by prior functional work]; (2) the pathway elevation reflects a cell-type composition difference — responders may harbor more of the cell type that normally expresses this pathway; (3) the elevation is driven by an upstream event associated with response, not the pathway itself. Before concluding the pathway is mechanistically relevant, the most important step is to check whether the signal persists after correcting for composition (deconvolution or single-cell data). If it does, functional perturbation in a relevant model would be the next step."
+
+---
+
+## Example 3: Knockout null phenotype
+
+**User:** The knockout showed no phenotype. Does gene Y not matter?
+
+**Pattern:**
+- Distinguish absence of evidence from evidence of absence
+- List biology-specific reasons a null phenotype may not mean no function
+- Propose the most informative follow-up considering biological context
+
+**Preferred style:**
+"A null phenotype in this context is consistent with gene Y being dispensable under these conditions, but it does not establish that gene Y has no function (from background knowledge). In biology, several mechanisms routinely mask phenotypes: genetic redundancy with a paralog, transcriptional compensation triggered by the knockout itself, context-dependence (the phenotype may require stress, infection, aging, or a specific developmental window), or insufficient sensitivity of the readout in the model used. The most informative next step depends on which alternative is most likely: if redundancy is suspected, test double knockouts; if context-dependence is likely, challenge the animal with the relevant stimulus; if the readout was insufficiently sensitive, try more granular measures (scRNA-seq, functional assays, or aged animals)."
+
+---
+
+## Example 4: Experimental design choice
+
+**User:** Should I use bulk RNA-seq or scRNA-seq to study this?
+
+**Pattern:**
+- Clarify what the scientific question requires at which biological level
+- Map each design to what it can and cannot answer
+- State the leading recommendation and the key assumption it rests on
+- Note relevant practical tradeoffs
+
+**Preferred style:**
+"The right choice depends on the biological question. If your question is about average gene expression differences across a relatively homogeneous population (e.g., a purified cell type before and after treatment), bulk RNA-seq provides higher sensitivity per gene and better statistical power at lower cost. If the question involves cellular heterogeneity — mixed populations, rare cell states, cell-type composition changes, or cell-state transitions — scRNA-seq is necessary because bulk averaging obscures those differences. The leading recommendation is scRNA-seq if your sample contains mixed or heterogeneous cells, or if you don't yet know the composition. The key assumption is that you have enough cells and sufficient depth to detect the subpopulations of interest; if budget or cell number is limited, a tiered approach (bulk first, single-cell on a subset) is worth considering."
+
+---
+
+## Example 5: GWAS hit and causal inference
+
+**User:** This GWAS hit implicates protein Z as a driver of disease risk.
+
+**Pattern:**
+- Separate GWAS association from causal inference
+- List the steps required to move from locus to causal effector
+- State clearly what current evidence supports and what it does not
+
+**Preferred style:**
+"A GWAS hit shows that a variant near the protein Z locus is statistically associated with disease risk at the population level (from provided data). This supports that the locus is involved, but does not establish protein Z as the causal effector — several steps are required to make that move: (1) fine-mapping to identify the functional variant(s) within the locus; (2) eQTL or pQTL analysis to link the variant to protein Z expression or function; (3) Mendelian randomization to test causal directionality; (4) functional perturbation in a relevant cell type or animal model. Until those steps are taken, the correct statement is 'the protein Z locus is associated with disease risk'; the 'driver' claim requires additional evidence. It is also possible the causal gene in the locus is not protein Z itself but a neighboring gene in LD."
+
+---
+
+## Example 6: Reconciling conflicting papers
+
+**User:** Paper A found pathway X is activated; paper B found it is suppressed. Which is right?
+
+**Pattern:**
+- Do not assume one paper is wrong
+- Systematically identify experimental differences that could explain the conflict
+- Propose a resolution strategy
+
+**Preferred style:**
+"Before concluding one paper is wrong, examine whether the experimental differences could legitimately produce opposite results: different cell types or tissues (pathway X may be activated in epithelial cells but suppressed in immune cells), different timepoints (transient activation followed by suppression is common in signaling), different disease stages, different species or strains, different stimuli or doses, different readout methods measuring different nodes of the pathway, or different genetic backgrounds. The most productive next step is to map these variables across both papers and identify the most likely source of the discrepancy. If all major variables appear identical, a direct head-to-head comparison in the same controlled system — with both labs' reagents — is the only way to resolve a genuine contradiction."
+
+---
+
+## Example 7: In vitro finding and translatability
+
+**User:** We showed that compound X kills tumor cells in culture. Can we move forward with this?
+
+**Pattern:**
+- Name what in vitro evidence does and does not establish
+- List the biological gaps between cell culture and in vivo efficacy
+- Recommend the next stage of validation without being dismissive
+
+**Preferred style:**
+"The in vitro result shows that compound X has cytotoxic or growth-inhibitory activity in cultured tumor cells under these conditions (from provided data). This is a necessary first step, but in vitro results frequently fail to predict in vivo efficacy for well-understood reasons: cultured cells lack the tumor microenvironment (stromal, immune, vascular components), pharmacokinetics and bioavailability are not captured, concentration in culture may not be achievable in vivo, and cell lines may carry genetic alterations that sensitize them atypically. Before moving forward, the minimum next steps are: (1) confirm activity in more representative models (patient-derived organoids or PDX if feasible); (2) assess selectivity against normal cells; (3) test in vivo with pharmacokinetically informed dosing. If those hurdles are cleared, the compound has a meaningful case for further development."
+
+---
+
+## Example 8: Single-cell cluster interpretation
+
+**User:** I see a cluster in my scRNA-seq data that expresses Foxp3 and Il2ra. Is this regulatory T cells?
+
+**Pattern:**
+- Distinguish marker-based labeling from validated cell identity
+- List what additional evidence would strengthen the annotation
+- Note potential confounders specific to scRNA-seq
+
+**Preferred style:**
+"A cluster expressing Foxp3 and Il2ra (CD25) is consistent with regulatory T cells — these are canonical Treg markers. However, in scRNA-seq, cluster labels based on marker gene expression are phenotypic annotations, not validated identities. Foxp3 can be transiently upregulated in activated non-Treg T cells, and Il2ra is also expressed on recently activated effector T cells. To strengthen the annotation: (1) check for the broader Treg gene signature (Ctla4, Ikzf2/Helios, Entpd1/CD39, Tnfrsf18/GITR) rather than two markers alone; (2) assess the cluster in a reference-based annotation tool (e.g., SingleR with a validated Treg reference); (3) if possible, validate with protein-level co-staining (FACS or CITE-seq). Also check for doublet contamination if the cluster has an unusually broad or mixed profile."
+
+---
+
+## Example 9: Mouse model to human biology
+
+**User:** This pathway is essential in mouse models of this disease. Does it work the same way in humans?
+
+**Pattern:**
+- Acknowledge the mouse evidence
+- Enumerate known translation gaps for this type of biology
+- Suggest what human evidence would be needed
+
+**Preferred style:**
+"Mouse model evidence establishes that this pathway is necessary for disease progression in that experimental system (from provided data/background knowledge). However, translation to human biology requires caution — mouse and human biology differ in ways that often matter: immune system composition and regulation differ substantially (e.g., mouse NK cells, neutrophil proportions, cytokine biology); some pathways are redundant in humans but essential in mice (or vice versa); disease kinetics, organ architecture, and metabolic rates differ. To evaluate whether the same pathway is operative in humans, look for: (1) genetic evidence in human GWAS or Mendelian disease linking this pathway to disease; (2) expression or activity differences in human patient samples vs. controls; (3) ex vivo functional evidence in primary human cells; (4) clinical trial data with a pathway inhibitor. Mouse results justify the hypothesis; they are not sufficient by themselves to confirm human relevance."
+
+---
+
+## Example 10: Evolutionary argument in biology
+
+**User:** Gene W is conserved across vertebrates — does that mean it's essential?
+
+**Pattern:**
+- Clarify what evolutionary conservation implies and does not imply
+- Distinguish sequence conservation from functional conservation
+- Note that essentiality may be context-dependent
+
+**Preferred style:**
+"Sequence conservation across vertebrates is consistent with purifying selection and suggests that the gene has been maintained because mutations are costly — this is evidence of functional importance, not proof of strict essentiality (from background knowledge). Several caveats apply: (1) essentiality depends on context — some highly conserved genes have subtle or conditional phenotypes when knocked out; (2) conservation at the sequence level does not guarantee conservation of function — a conserved gene may serve different roles in different organisms; (3) pleiotropy may constrain a gene's evolution even if its role in any specific process is not essential. The strongest evidence for essentiality is a severe loss-of-function phenotype across multiple genetic perturbations and species. Conservation raises the prior probability that perturbation will matter — it is a strong motivation to test, not a substitute for testing."


### PR DESCRIPTION
Retire the standalone Agents365-ai/scientific-thinking-skill repo: add the skill as plugins/scientific-thinking-biology (SKILL.md, checks.md, examples.md, plugin READMEs + MIT license; no agents/ sidecar in the source), point clone instructions, cross-links and SKILL.md homepage at the monorepo, and register it in .claude-plugin/marketplace.json (v1.0.0, MIT). Carries the source repo's uncommitted working-tree reference rename (single-cell-multiomics -> nh-bioinfo-practice-skill) in README.md / README_CN.md / SKILL.md.