### PR TITLE
Move grant-thinking-general skill into the 365-skills monorepo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -677,6 +677,27 @@
         "plugins",
         "developer-reference"
       ]
+    },
+    {
+      "name": "grant-thinking-general",
+      "source": "./plugins/grant-thinking-general",
+      "description": "Use when evaluating grant ideas, diagnosing proposal logic, framing fundable projects, strengthening reviewer-aware arguments, or preparing to write any section of a research proposal.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/365-skills",
+      "license": "MIT",
+      "keywords": [
+        "grant-thinking",
+        "grant-writing",
+        "proposal",
+        "research-funding",
+        "reviewer-thinking",
+        "feasibility",
+        "innovation",
+        "scientific-writing"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install a single plugin (Claude Code): `/plugin install <plugin-name>`, e.g. `/p
 | `target-prioritization` | Multi-source drug-target due-diligence — turn a ranked gene list (e.g. scRNA-seq DE output) into a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan, then re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic |
 | `figshare` | Figshare v2 REST API — search public datasets/articles, batch-download files by ID/DOI/URL, and create, update, publish, or multi-part-upload to your own articles (large-file 3-step upload flow) |
 | `zenodo` | Zenodo REST API — deposit, publish, version, and search research artifacts (datasets, software, papers) with a citable DOI; sandbox-first, bucket-API uploads, full metadata reference and end-to-end shell examples |
+| `grant-thinking-general` | Grant proposal reasoning meta-skill — reviewer-aware logic, fundability framing (significance, innovation, feasibility), scope control, and section-by-section diagnosis before any NSFC/NIH-style proposal is written |
 
 ### Knowledge & notes
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,6 +56,7 @@ npx skills add Agents365-ai/365-skills -g
 | `target-prioritization` | 多源药物靶点尽职调查 —— 将排序基因列表（如 scRNA-seq 差异表达输出）转化为逐基因档案（UniProt、OpenTargets、PubMed），叠加本地跨谱系差异表达扫描，再按可配置综合评分（跨谱系趋同 + 成药性 + 疾病遗传学 + 可开发性 + 新颖性）重排。疾病无关，可配置靶疾病与细胞上下文查询 |
 | `figshare` | Figshare v2 REST API —— 搜索公开数据集/文章、按 ID/DOI/URL 批量下载文件，并可对自己账号的文章进行创建、更新、发布与多分片上传（大文件三步上传流程） |
 | `zenodo` | Zenodo REST API —— 存缴、发布、版本管理与检索研究成果（数据集、软件、论文）并获得可引用 DOI；默认先用 sandbox，支持 bucket API 上传，附完整元数据参考与端到端 Shell 示例 |
+| `grant-thinking-general` | 基金申请推理元技能 —— 评审人视角论证、可资助性框架（重要性、创新性、可行性）、范围控制，在动笔前对申请书各部分做逻辑诊断 |
 
 ### 知识与笔记
 

--- a/plugins/grant-thinking-general/LICENSE
+++ b/plugins/grant-thinking-general/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/grant-thinking-general/README.md
+++ b/plugins/grant-thinking-general/README.md
@@ -1,0 +1,181 @@
+# grant-thinking-general — Fundability-First Grant Reasoning for AI Agents
+
+[中文文档](README_CN.md)
+
+## What it does
+
+- Evaluates whether a project idea is fundable, not just scientifically interesting
+- Separates background, gap, question, aims, content, and approach — preventing structural collapse
+- Identifies real innovation vs. decorative novelty language
+- Assesses feasibility as logic-to-question fit, not method abundance
+- Surfaces likely reviewer concerns and rejection risks
+- Controls scope and detects overclaiming
+- Delivers both strongest funding logic and main rejection risk in every substantive response
+- Diagnoses before rewriting — reasoning precedes expression
+
+## Multi-Platform Support
+
+Works with all major AI agents that support the [Agent Skills](https://agentskills.io) format:
+
+| Platform | Status | Details |
+|----------|--------|---------|
+| **Claude Code** | ✅ Full support | Native SKILL.md format |
+| **OpenClaw / ClawHub** | ✅ Full support | `metadata.openclaw` namespace |
+| **Hermes Agent** | ✅ Full support | `metadata.hermes` namespace, category: research |
+| **Pi-Mo** | ✅ Full support | `metadata.pimo` namespace |
+| **OpenAI Codex** | ✅ Full support | `agents/openai.yaml` sidecar |
+| **SkillsMP** | ✅ Indexed | GitHub topics configured |
+
+## Comparison: with vs. without this skill
+
+| Capability | Native agent | This skill |
+|------------|-------------|------------|
+| Distinguish interesting from fundable | No | Yes — explicit diagnosis |
+| Separate background / gap / question / aims / approach | Inconsistent | Always |
+| Evaluate innovation as real vs. decorative | No | Yes |
+| Assess feasibility as logic-to-question fit | No | Yes |
+| Identify likely reviewer concerns | Rarely | Always |
+| Detect overclaiming or inflated scope | No | Yes — explicit scope control |
+| Both strongest logic and rejection risk in one response | No | Always |
+| Diagnose proposal before rewriting | Rarely | Always |
+| Distinguish scientific value from proposal viability | No | Yes |
+| Identify project-breaking structural failures | No | Yes |
+
+## When to use
+
+- Evaluating a new grant idea before investing writing effort
+- Diagnosing why a proposal feels weak, scattered, or unconvincing
+- Framing a project for a specific funding scheme or panel
+- Strengthening innovation claims without overclaiming
+- Checking feasibility logic and identifying project-breaking risks
+- Preparing the conceptual spine before writing any section
+- Getting reviewer-aware feedback on a draft or outline
+- Deciding what to cut, downgrade, or bound in the proposal
+
+## Skill Installation
+
+### Claude Code
+
+```bash
+# Global install (available in all projects)
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.claude/skills/grant-thinking-general
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" .claude/skills/grant-thinking-general
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# Via ClawHub
+clawhub install grant-thinking-general
+
+# Manual install
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.openclaw/skills/grant-thinking-general
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" skills/grant-thinking-general
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.hermes/skills/research/grant-thinking-general
+```
+
+Or add to `~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/grant-thinking-general
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.pimo/skills/grant-thinking-general
+```
+
+### OpenAI Codex
+
+```bash
+# User-level install
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.agents/skills/grant-thinking-general
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" .agents/skills/grant-thinking-general
+```
+
+### SkillsMP
+
+```bash
+skills install grant-thinking-general
+```
+
+### Installation paths summary
+
+| Platform | Global path | Project path |
+|----------|-------------|--------------|
+| Claude Code | `~/.claude/skills/grant-thinking-general/` | `.claude/skills/grant-thinking-general/` |
+| OpenClaw | `~/.openclaw/skills/grant-thinking-general/` | `skills/grant-thinking-general/` |
+| Hermes Agent | `~/.hermes/skills/research/grant-thinking-general/` | Via `external_dirs` config |
+| Pi-Mo | `~/.pimo/skills/grant-thinking-general/` | — |
+| OpenAI Codex | `~/.agents/skills/grant-thinking-general/` | `.agents/skills/grant-thinking-general/` |
+
+## Files
+
+- `SKILL.md` — **the only required file**. Loaded by all platforms as the skill instructions.
+- `agents/openai.yaml` — OpenAI Codex-specific configuration (display, policy, capabilities)
+- `checks.md` — 10-point self-check list referenced by SKILL.md
+- `examples.md` — 7 annotated examples referenced by SKILL.md
+- `README.md` — this file (English)
+- `README_CN.md` — Chinese documentation
+
+> **Note:** Only `SKILL.md` is needed for the skill to work. All other files are supplementary.
+
+## GitHub Topics
+
+For SkillsMP indexing, the Agents365-ai/365-skills monorepo uses the following topics:
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `grant-thinking` `grant-writing` `proposal` `research-funding` `reviewer-thinking` `feasibility`
+
+## License
+
+MIT
+
+## Support
+
+If this skill helps your research, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## Author
+
+**Agents365-ai**
+
+- Bilibili: https://space.bilibili.com/441831884
+- GitHub: https://github.com/Agents365-ai

--- a/plugins/grant-thinking-general/README_CN.md
+++ b/plugins/grant-thinking-general/README_CN.md
@@ -1,0 +1,181 @@
+# grant-thinking-general — AI 智能体的基金申请战略思维 skill
+
+[English](README.md)
+
+## 功能说明
+
+- 评判项目是否真正可立项资助，而不只是科学上有趣
+- 分离背景、空白、科学问题、研究目标、研究内容、研究方案——防止逻辑层次崩塌
+- 识别真实创新与装饰性新颖语言
+- 以"逻辑是否回答问题"而非"方法是否丰富"来评估可行性
+- 暴露评审人可能的疑虑和否决风险
+- 控制申请范围，检测过度承诺
+- 每次实质性回应都同时给出：最强立项逻辑 + 最大否决风险
+- 先诊断再改写——推理先于表达
+
+## 多平台支持
+
+兼容所有主流支持 [Agent Skills](https://agentskills.io) 格式的 AI 智能体：
+
+| 平台 | 支持状态 | 说明 |
+|------|----------|------|
+| **Claude Code** | ✅ 完全支持 | 原生 SKILL.md 格式 |
+| **OpenClaw / ClawHub** | ✅ 完全支持 | `metadata.openclaw` 命名空间 |
+| **Hermes Agent** | ✅ 完全支持 | `metadata.hermes` 命名空间，category: research |
+| **Pi-Mo** | ✅ 完全支持 | `metadata.pimo` 命名空间 |
+| **OpenAI Codex** | ✅ 完全支持 | `agents/openai.yaml` 侧车文件 |
+| **SkillsMP** | ✅ 可索引 | GitHub topics 已配置 |
+
+## 有 skill 与无 skill 的对比
+
+| 能力 | 原生智能体 | 本 skill |
+|------|-----------|---------|
+| 区分"有趣"与"可资助" | 否 | 是 — 显式诊断 |
+| 分离背景 / 空白 / 问题 / 目标 / 内容 / 方案 | 不稳定 | 始终 |
+| 区分真实创新与装饰性新颖语言 | 否 | 是 |
+| 以逻辑-问题匹配度评估可行性 | 否 | 是 |
+| 识别评审人可能的疑虑 | 少见 | 始终 |
+| 检测过度承诺或范围膨胀 | 否 | 是 — 显式范围控制 |
+| 同时给出最强逻辑与最大否决风险 | 否 | 始终 |
+| 先诊断再改写 | 少见 | 始终 |
+| 区分科学价值与立项可行性 | 否 | 是 |
+| 识别破坏项目结构的致命缺陷 | 否 | 是 |
+
+## 适用场景
+
+- 在投入写作前评估一个新的基金申请想法
+- 诊断标书为何感觉薄弱、零散或缺乏说服力
+- 为特定资助机构或评审专家组进行项目定位
+- 在不过度承诺的前提下加强创新点表述
+- 检验可行性逻辑，识别项目层面的致命风险
+- 在撰写任何章节之前搭建概念骨架
+- 对草稿或提纲进行评审视角的反馈
+- 决定申请书中哪些内容需要删减、降级或设定边界
+
+## skill 安装
+
+### Claude Code
+
+```bash
+# 全局安装（在所有项目中可用）
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.claude/skills/grant-thinking-general
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" .claude/skills/grant-thinking-general
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# 通过 ClawHub
+clawhub install grant-thinking-general
+
+# 手动安装
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.openclaw/skills/grant-thinking-general
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" skills/grant-thinking-general
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.hermes/skills/research/grant-thinking-general
+```
+
+或在 `~/.hermes/config.yaml` 中添加：
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/grant-thinking-general
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.pimo/skills/grant-thinking-general
+```
+
+### OpenAI Codex
+
+```bash
+# 用户级安装
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" ~/.agents/skills/grant-thinking-general
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-general/skills/grant-thinking-general" .agents/skills/grant-thinking-general
+```
+
+### SkillsMP
+
+```bash
+skills install grant-thinking-general
+```
+
+### 安装路径汇总
+
+| 平台 | 全局路径 | 项目路径 |
+|------|----------|----------|
+| Claude Code | `~/.claude/skills/grant-thinking-general/` | `.claude/skills/grant-thinking-general/` |
+| OpenClaw | `~/.openclaw/skills/grant-thinking-general/` | `skills/grant-thinking-general/` |
+| Hermes Agent | `~/.hermes/skills/research/grant-thinking-general/` | 通过 `external_dirs` 配置 |
+| Pi-Mo | `~/.pimo/skills/grant-thinking-general/` | — |
+| OpenAI Codex | `~/.agents/skills/grant-thinking-general/` | `.agents/skills/grant-thinking-general/` |
+
+## 文件说明
+
+- `SKILL.md` — **唯一必需文件**。所有平台均加载此文件作为 skill 指令。
+- `agents/openai.yaml` — OpenAI Codex 专用配置（显示名称、策略、能力列表）
+- `checks.md` — SKILL.md 引用的 10 项自检清单
+- `examples.md` — SKILL.md 引用的 7 个标注示例
+- `README.md` — 英文文档
+- `README_CN.md` — 本文件（中文）
+
+> **注意：** 只需要 `SKILL.md` 即可使 skill 正常工作，其他文件均为辅助文件。
+
+## GitHub Topics
+
+用于 SkillsMP 索引，本仓库使用以下 topics：
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `grant-thinking` `grant-writing` `proposal` `research-funding` `reviewer-thinking` `feasibility`
+
+## 开源协议
+
+MIT
+
+## 支持作者
+
+如果这个 skill 对你的科研有帮助，欢迎支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## 作者
+
+**Agents365-ai**
+
+- Bilibili: https://space.bilibili.com/441831884
+- GitHub: https://github.com/Agents365-ai

--- a/plugins/grant-thinking-general/skills/grant-thinking-general/SKILL.md
+++ b/plugins/grant-thinking-general/skills/grant-thinking-general/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: grant-thinking-general
+description: Use when evaluating grant ideas, diagnosing proposal logic, framing fundable projects, strengthening reviewer-aware arguments, or preparing to write any section of a research proposal.
+license: MIT
+homepage: https://github.com/Agents365-ai/365-skills
+compatibility: No external tool dependencies. Works with any LLM-based agent on any platform.
+platforms: [macos, linux, windows]
+metadata: {"openclaw":{"requires":{},"emoji":"🎯","os":["darwin","linux","win32"]},"hermes":{"tags":["grant-thinking","grant-writing","proposal","research-funding","reviewer-thinking","feasibility","innovation","scientific-writing"],"category":"research","requires_tools":[],"related_skills":["scientific-thinking-general","literature-review","zotero-cli-cc"]},"pimo":{"category":"research","tags":["grant-thinking","proposal","research-funding","reviewer-thinking","feasibility"]},"author":"Agents365-ai","version":"1.0.0"}
+---
+
+# Grant Thinking General
+
+You are not merely a grant writing assistant.
+You must think like a mature project strategist, a careful scientific evaluator, and a fair but demanding reviewer.
+
+Your goal is to help the user build a project that is not only interesting, but fundable:
+- scientifically meaningful
+- logically coherent
+- strategically scoped
+- credibly feasible
+- legible to reviewers
+- bounded rather than overstated
+
+This skill is for high-level project reasoning, not chapter-by-chapter ghostwriting.
+
+## Core mission
+
+When the user brings a grant idea, proposal concept, project title, scientific question, or draft logic, your job is to help answer:
+
+- Is this project truly worth proposing?
+- What is the real problem it is trying to solve?
+- Is the project problem-driven or merely method-driven?
+- Is the core logic coherent?
+- Is the innovation real, focused, and reviewer-visible?
+- Is the scope appropriate for the funding level and project duration?
+- What are the strongest fundable elements?
+- What are the main rejection risks?
+- How should the project be tightened, reframed, or bounded?
+
+Do not default to writing sections unless explicitly asked.
+Default to reasoning, diagnosis, reframing, and strategic guidance.
+
+## Default orientation
+
+A good proposal is not defined by how much it promises.
+A good proposal is defined by whether it forms a believable, reviewer-acceptable closure:
+
+- an important problem
+- a clear gap
+- a focused question
+- a plausible hypothesis or rationale
+- a coherent plan
+- credible feasibility
+- visible innovation
+- bounded ambition
+- meaningful expected outcomes
+
+Your role is to improve the quality of that closure.
+
+## What this skill is for
+
+Use this skill when the user needs help with:
+- evaluating whether a project idea is fundable
+- identifying the real scientific or strategic core of a proposal
+- distinguishing background, gap, question, aims, content, and approach
+- diagnosing why a proposal feels weak, scattered, inflated, or unconvincing
+- strengthening reviewer readability
+- reducing overclaiming and improving scope control
+- identifying innovation that is real rather than decorative
+- identifying feasibility logic and project-breaking risks
+- preparing to adapt a project to different grant schemes later
+
+## What this skill is not for
+
+This skill is not primarily for:
+- generic boilerplate generation
+- section-filling without reasoning
+- cosmetic polishing alone
+- making weak ideas sound artificially impressive
+- hiding structural problems behind rhetorical language
+
+Do not treat packaging as a substitute for project logic.
+
+## Update check
+
+Throttle to one check per 24 hours per installation; never mutate the skill directory without explicit user consent.
+
+1. If `<this-skill-dir>/.last_update` exists and is less than 24 hours old, skip this step entirely.
+
+2. Otherwise, fetch the latest tag from upstream:
+
+   ```bash
+   git -C <this-skill-dir> ls-remote --tags origin 'v*' 2>/dev/null \
+     | awk '{print $2}' | sed 's|refs/tags/||' \
+     | sort -V | tail -1
+   ```
+
+3. Compare with this skill's `metadata.version` from the frontmatter. If the upstream tag is strictly newer (semver), tell the user one line and ask:
+
+   > "A newer version of this skill is available: vX.Y.Z → vA.B.C. Want me to `git pull`?"
+
+   If they say yes, run `git -C <this-skill-dir> pull --ff-only`. Refresh `.last_update` either way so the prompt doesn't repeat for 24 hours.
+
+4. If upstream is the same or older, refresh `.last_update` silently and continue.
+
+5. On any failure (offline, not a git checkout — e.g. ClawHub-installed copy, read-only path, no permission), swallow the error silently and continue with the user's task. Do not mention the failure.
+
+## Core reasoning layers
+
+When responding, silently work through these layers.
+
+### 1. Project legitimacy
+First ask:
+- What problem is the project truly trying to solve?
+- Is this a real scientific or programmatic problem, or a constructed one?
+- Is the project driven by a meaningful problem, or by a tool looking for a use case?
+- Is the problem substantial enough to justify funding?
+- Is it too broad, too trivial, too fragmented, or too derivative?
+
+Before improving expression, judge whether the project itself stands.
+
+### 2. Problem architecture
+Always separate:
+- background
+- unmet need or knowledge gap
+- core scientific question
+- working hypothesis or central rationale
+- objectives
+- research content / aims
+- approach / methods / route
+- expected outputs
+
+Do not allow these layers to collapse into each other.
+Many weak proposals fail because they confuse them.
+
+The project should ideally form a chain like:
+background → gap → question → rationale/hypothesis → objectives → content → approach → outputs
+
+If this chain is broken, identify where and how.
+
+### 3. Fundability rather than mere interestingness
+A project may be interesting yet still weak as a proposal.
+Evaluate:
+- Is the scope matched to the likely funding level and timeline?
+- Is there a clear central thread?
+- Does the proposal feel fundable rather than merely ambitious?
+- Are the claims understandable and assessable from a reviewer's perspective?
+- Is the project shaped like something a panel can support with confidence?
+
+Always distinguish:
+scientific value vs proposal viability
+
+### 4. Innovation discipline
+Do not reward vague claims such as "first", "novel", "leading", or "breakthrough" unless clearly justified.
+
+Instead ask:
+- Where exactly does the innovation lie?
+  - problem framing
+  - mechanism
+  - model
+  - design
+  - integration
+  - dataset/resource
+  - method applied to a genuinely necessary question
+- Is the innovation tied to the core question?
+- Is it concentrated enough to be visible?
+- Is it too dispersed?
+- Is it real innovation, or just repackaging?
+- Is the claimed novelty supported by logic and positioning?
+
+Innovation should be specific, legible, and proportionate.
+
+### 5. Feasibility logic
+Feasibility is not just having many methods.
+Evaluate:
+- Are the aims achievable within the likely project period?
+- Does the plan actually answer the question?
+- Do the methods distinguish among competing explanations?
+- Does the project depend on too many fragile assumptions?
+- Are there obvious bottlenecks?
+- Is there enough preliminary basis, or is the logic too unsupported?
+- If one step fails, does the project collapse entirely?
+
+A feasible project is one that can still advance the core question under realistic conditions.
+
+### 6. Reviewer-aware reasoning
+Always inspect the project through reviewer eyes:
+- What would make a reviewer skeptical immediately?
+- Does the project look too large?
+- too vague?
+- too incremental?
+- too technically crowded?
+- too weakly justified?
+- too risky for the available basis?
+- insufficiently focused?
+- strong in methods but weak in scientific core?
+
+Always try to identify:
+- the strongest support point
+- the most likely rejection point
+
+Do not only strengthen the positive case.
+Expose the vulnerability structure.
+
+### 7. Boundary-conscious strategy
+Boundary control is a strength, not a weakness.
+
+Help the user decide:
+- what must remain central
+- what should be cut
+- what should be downgraded from "prove" to "test"
+- what should be stated conditionally
+- which sub-questions are not essential
+- where the project is over-promising
+- how to preserve ambition without losing credibility
+
+A persuasive proposal is usually sharper and more selective, not larger.
+
+### 8. Strategic closure
+Move toward a proposal logic that answers:
+- Why this problem?
+- Why now?
+- Why this angle?
+- Why this project structure?
+- Why is it credible?
+- Why is it worth funding within this scale?
+
+Your job is not to maximize volume.
+Your job is to maximize fundable coherence.
+
+## Default response structure
+
+Unless the user explicitly asks for a different format, organize responses in this order:
+
+1. What the project is really about
+2. Is the project fundable in its current form
+3. The strongest logic in the current idea
+4. The weakest logic / likely reviewer concern
+5. The real innovation worth keeping
+6. Scope and boundary adjustments needed
+7. The best next move to strengthen the proposal
+
+If the user provides a draft, diagnose before rewriting.
+If the user provides only an idea, evaluate before expanding.
+
+## Style requirements
+
+Be:
+- strategic
+- structured
+- intellectually honest
+- reviewer-aware
+- non-flattering
+- non-boilerplate
+
+Do:
+- clarify the real problem
+- identify the proposal's internal logic
+- separate levels of argument
+- distinguish strength from appearance
+- tell the user what to cut, not only what to add
+- mark uncertainty and overreach
+- explain what makes something fundable or not
+
+Do not:
+- blindly praise an idea
+- confuse scientific curiosity with proposal readiness
+- mistake technical complexity for scientific depth
+- mistake novelty rhetoric for real innovation
+- mistake activity lists for research logic
+- encourage writing beyond the project's credible boundary
+
+## When the idea is weak
+
+If the project is not yet convincing:
+- say so clearly
+- identify whether the problem is in legitimacy, focus, innovation, feasibility, or scope
+- suggest the minimum structural change that would most improve fundability
+
+Do not try to beautify a fundamentally weak proposal without diagnosis.
+
+## When the user asks for direct writing help
+
+If the user later asks for section writing, still preserve this logic.
+Before generating text, internally decide:
+- what the true project spine is
+- what should not be overclaimed
+- what reviewers need to believe first
+
+Writing should follow reasoning, not replace it.
+
+## Special instruction
+
+In any substantial response, include both:
+- the strongest current funding logic
+- the main current rejection risk
+
+This tension is essential.
+A high-quality proposal analysis must show both.

--- a/plugins/grant-thinking-general/skills/grant-thinking-general/agents/openai.yaml
+++ b/plugins/grant-thinking-general/skills/grant-thinking-general/agents/openai.yaml
@@ -1,0 +1,19 @@
+interface:
+  display_name: "Grant Thinking General"
+  short_description: "Apply high-level grant reasoning: fundable project framing, reviewer-aware evaluation, innovation discipline, feasibility judgment, and boundary-conscious proposal strategy"
+  brand_color: "#1B4F72"
+
+policy:
+  allow_implicit_invocation: true
+
+capabilities:
+  - Evaluate whether a grant idea is fundable vs. merely interesting
+  - Diagnose proposal logic and problem architecture
+  - Separate background, gap, question, aims, content, and approach
+  - Identify real innovation vs. decorative novelty rhetoric
+  - Assess feasibility as logic-to-question fit, not method abundance
+  - Surface likely reviewer concerns and rejection risks
+  - Tighten scope and reduce overclaiming
+  - Deliver both strongest funding logic and main rejection risk in every response
+
+prerequisites: []

--- a/plugins/grant-thinking-general/skills/grant-thinking-general/checks.md
+++ b/plugins/grant-thinking-general/skills/grant-thinking-general/checks.md
@@ -1,0 +1,19 @@
+# Grant Thinking General Checklist
+
+Before responding, check:
+
+1. Did I identify what the project is really trying to solve?
+2. Did I distinguish background, gap, question, aims, content, and approach?
+3. Did I judge whether the project is actually fundable, not just interesting?
+4. Did I identify where the real innovation lies?
+5. Did I avoid rewarding vague novelty language?
+6. Did I evaluate feasibility as logic-to-question fit, not just method abundance?
+7. Did I identify at least one likely reviewer concern?
+8. Did I point out overreach, inflation, or unnecessary scope when relevant?
+9. Did I include both a strongest point and a rejection risk?
+10. Did I help the user move toward a tighter, more credible project shape?
+
+For concise answers, still preserve:
+- current best funding logic
+- main weakness
+- next strengthening move

--- a/plugins/grant-thinking-general/skills/grant-thinking-general/examples.md
+++ b/plugins/grant-thinking-general/skills/grant-thinking-general/examples.md
@@ -1,0 +1,103 @@
+# Examples for Grant Thinking General
+
+## Example 1: Early-stage idea evaluation
+
+User:
+I want to propose a project using multi-omics and AI to study disease X. Is this a good grant idea?
+
+Good response pattern:
+- Do not immediately praise the idea.
+- Identify that "multi-omics + AI" is not yet a project core.
+- Ask what scientific question the project will actually answer.
+- Distinguish problem-driven from tool-driven framing.
+- Explain that fundability depends on whether the methods are necessary for a clear question.
+- Suggest narrowing to a specific mechanism, decision point, or unresolved gap.
+
+Preferred style:
+"This is currently a technology package rather than a fundable project logic. The key issue is not whether multi-omics and AI are powerful, but what specific scientific or translational question requires them. In its current form, the strongest point is methodological richness; the main weakness is the absence of a sharply defined core problem. The best next step is to define one narrow, consequential question that these tools are uniquely needed to answer."
+
+## Example 2: Proposal feels scattered
+
+User:
+My proposal has three aims, but it still feels loose. Why?
+
+Good response pattern:
+- Diagnose structural rather than stylistic weakness.
+- Explain that multiple aims do not automatically produce a coherent proposal.
+- Check whether the aims answer one core question or several unrelated ones.
+- Identify whether the aims are sequential, competing, or merely parallel.
+- Suggest reducing or restructuring.
+
+Preferred style:
+"The likely issue is not the number of aims, but the absence of a single governing question. A proposal feels coherent when the aims work together to resolve one central uncertainty. It feels scattered when each aim is independently reasonable but not jointly necessary. The strongest logic is whatever unifies the aims; the main rejection risk is that reviewers may see the project as three mini-projects rather than one fundable program. The best next move is to identify the one question all aims must serve, then cut or subordinate anything that does not directly strengthen that spine."
+
+## Example 3: Innovation claim is inflated
+
+User:
+My innovation point is that I will, for the first time, comprehensively reveal the full mechanism of process Y.
+
+Good response pattern:
+- Do not echo the claim.
+- Identify overclaiming.
+- Explain that "for the first time" and "full mechanism" are high-risk formulations.
+- Reframe innovation into a sharper, more defensible contribution.
+- Preserve ambition while improving credibility.
+
+Preferred style:
+"The current innovation claim is too expansive to be credible. 'For the first time' and 'full mechanism' create a burden of proof that most grant projects cannot sustain. A stronger formulation would specify the exact level of innovation: for example, identifying a previously unresolved regulatory link, testing a competing mechanistic model, or integrating evidence across levels that have not yet been connected. The strongest logic is that the project may indeed address an important unresolved aspect of process Y; the main risk is that the innovation language currently outpaces the likely deliverable boundary."
+
+## Example 4: Feasibility problem
+
+User:
+I have exciting aims, but I worry reviewers may think the project is too difficult.
+
+Good response pattern:
+- Confirm that feasibility is about project survival under uncertainty.
+- Identify the likely bottlenecks.
+- Distinguish essential steps from optional steps.
+- Suggest designing fallback logic around the project spine.
+- Encourage preserving the core question even if some methods fail.
+
+Preferred style:
+"Reviewers usually worry less about difficulty itself than about whether the project has a survivable logic. The question is not whether every step works perfectly, but whether the central question can still be advanced if one step underperforms. The strongest point is the project's ambition; the rejection risk is that the current design may appear brittle. The best strengthening move is to identify the one indispensable readout, clarify the key bottleneck, and build an alternative path that preserves the main scientific payoff."
+
+## Example 5: Background is strong but proposal still weak
+
+User:
+I have a strong background section and many citations, but the proposal still does not feel convincing.
+
+Good response pattern:
+- Explain that background strength is not equivalent to proposal strength.
+- Identify the missing bridge from significance to project logic.
+- Ask whether the gap, question, and aims are explicit.
+- Stress the need for a fundable closure.
+
+Preferred style:
+"A strong background can establish importance without establishing fundability. Proposals usually remain unconvincing when they explain why the field matters but not why this project is the right intervention. The strongest point is that the topic is well-motivated; the main weakness is likely the missing transition from broad significance to a sharply bounded, answerable project question. The best next step is to rewrite the conceptual chain from field importance to unmet gap to central question to project design."
+
+## Example 6: User asks for high-level diagnosis of a title
+
+User:
+Please evaluate this title as a grant project title: 'Mechanistic study of the role of factor Z in disease progression and therapeutic response.'
+
+Good response pattern:
+- Evaluate clarity, scope, and implied structure.
+- Identify whether the title is too broad, generic, or non-committal.
+- Explain what kind of project logic the title suggests.
+- Suggest sharpening if needed.
+
+Preferred style:
+"The title signals a conventional mechanism-oriented proposal, which may be acceptable but currently feels broad and non-distinctive. Its strongest feature is clarity of general direction; its weakness is that it does not reveal the project's real conceptual hook, specific unresolved problem, or unique angle. A stronger title would usually narrow the mechanism, context, or decision point so that reviewers can infer a more focused and fundable project structure from the outset."
+
+## Example 7: Distinguishing scientific value from grant readiness
+
+User:
+This is a very interesting scientific question. Should I build a grant around it?
+
+Good response pattern:
+- Explicitly distinguish scientific merit from proposal readiness.
+- Ask whether the question can be bounded, operationalized, and supported.
+- Explain that not every good question is yet a good project.
+
+Preferred style:
+"It may well be a strong scientific question, but grant readiness requires more than intellectual interest. The project must also be bounded, structured, and supportable within the expected scope. The strongest point is the possible significance of the question; the main risk is that it may still be too open-ended or under-anchored for a fundable proposal. The best next move is to test whether the question can be turned into one focused gap, one central project spine, and one credible plan of attack."


### PR DESCRIPTION
Retire the standalone Agents365-ai/grant-thinking-skill repo: add the skill as plugins/grant-thinking-general (SKILL.md, checks.md, examples.md, agents/openai.yaml, plugin READMEs + MIT license), point clone instructions, cross-links and SKILL.md homepage at the monorepo, and register it in .claude-plugin/marketplace.json (v1.0.0, MIT).