### PR TITLE
Move grant-thinking-cn-biology skill into the 365-skills monorepo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -677,6 +677,29 @@
         "plugins",
         "developer-reference"
       ]
+    },
+    {
+      "name": "grant-thinking-cn-biology",
+      "source": "./plugins/grant-thinking-cn-biology",
+      "description": "Use when evaluating biology grant ideas in the Chinese funding context (NSFC, MOST, etc.) — diagnosing project legitimacy, mechanism-centered scientific questions, reviewer-aware logic, innovation discipline, feasibility, and scope control across funding levels (youth, general, key).",
+      "version": "1.0.0",
+      "author": {
+        "name": "Agents365-ai"
+      },
+      "repository": "https://github.com/Agents365-ai/365-skills",
+      "license": "MIT",
+      "keywords": [
+        "grant-thinking",
+        "biology",
+        "nsfc",
+        "china-grants",
+        "proposal",
+        "research-funding",
+        "reviewer-thinking",
+        "feasibility",
+        "mechanism",
+        "scientific-writing"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install a single plugin (Claude Code): `/plugin install <plugin-name>`, e.g. `/p
 | `target-prioritization` | Multi-source drug-target due-diligence — turn a ranked gene list (e.g. scRNA-seq DE output) into a per-gene dossier across UniProt, OpenTargets, and PubMed, plus a local cross-lineage DE scan, then re-rank by a configurable composite score (cross-lineage convergence + druggability + disease genetics + tractability + novelty). Disease-agnostic |
 | `figshare` | Figshare v2 REST API — search public datasets/articles, batch-download files by ID/DOI/URL, and create, update, publish, or multi-part-upload to your own articles (large-file 3-step upload flow) |
 | `zenodo` | Zenodo REST API — deposit, publish, version, and search research artifacts (datasets, software, papers) with a citable DOI; sandbox-first, bucket-API uploads, full metadata reference and end-to-end shell examples |
+| `grant-thinking-cn-biology` | Chinese NSFC-focused biology grant reasoning — mechanism-centered scientific questions, reviewer-aware logic, innovation discipline, feasibility and scope control across funding levels (youth / general / key) |
 
 ### Knowledge & notes
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,6 +56,7 @@ npx skills add Agents365-ai/365-skills -g
 | `target-prioritization` | 多源药物靶点尽职调查 —— 将排序基因列表（如 scRNA-seq 差异表达输出）转化为逐基因档案（UniProt、OpenTargets、PubMed），叠加本地跨谱系差异表达扫描，再按可配置综合评分（跨谱系趋同 + 成药性 + 疾病遗传学 + 可开发性 + 新颖性）重排。疾病无关，可配置靶疾病与细胞上下文查询 |
 | `figshare` | Figshare v2 REST API —— 搜索公开数据集/文章、按 ID/DOI/URL 批量下载文件，并可对自己账号的文章进行创建、更新、发布与多分片上传（大文件三步上传流程） |
 | `zenodo` | Zenodo REST API —— 存缴、发布、版本管理与检索研究成果（数据集、软件、论文）并获得可引用 DOI；默认先用 sandbox，支持 bucket API 上传，附完整元数据参考与端到端 Shell 示例 |
+| `grant-thinking-cn-biology` | 面向中国国家自然科学基金（NSFC）的生物类基金申请推理 —— 机制中心的科学问题、评审人视角逻辑、创新性纪律、可行性与范围控制，覆盖青年 / 面上 / 重点项目层级 |
 
 ### 知识与笔记
 

--- a/plugins/grant-thinking-cn-biology/LICENSE
+++ b/plugins/grant-thinking-cn-biology/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agents365-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/grant-thinking-cn-biology/README.md
+++ b/plugins/grant-thinking-cn-biology/README.md
@@ -1,0 +1,204 @@
+# grant-thinking-cn-biology — Biology Grant Reasoning for China's Funding Context
+
+[中文文档](README_CN.md)
+
+## What it does
+
+- Evaluates biology grant ideas for fundability in Chinese grant systems (NSFC, MOST, etc.)
+- Distinguishes descriptive projects from mechanism-driven proposals
+- Separates background, gap, question, hypothesis, aims, content, and methods — preventing structural collapse
+- Identifies real biological innovation vs. decorative novelty language
+- Assesses feasibility as biological-question fit, not method or platform abundance
+- Surfaces likely reviewer concerns specific to Chinese biology grant panels
+- Adapts reasoning to project level: youth (青年), general (面上), key (重点/课题)
+- Delivers both strongest funding logic and main rejection risk in every substantive response
+- Diagnoses before rewriting — reasoning precedes expression
+
+## Multi-Platform Support
+
+Works with all major AI agents that support the [Agent Skills](https://agentskills.io) format:
+
+| Platform | Status | Details |
+|----------|--------|---------|
+| **Claude Code** | ✅ Full support | Native SKILL.md format |
+| **OpenClaw / ClawHub** | ✅ Full support | `metadata.openclaw` namespace |
+| **Hermes Agent** | ✅ Full support | `metadata.hermes` namespace, category: research |
+| **Pi-Mo** | ✅ Full support | `metadata.pimo` namespace |
+| **OpenAI Codex** | ✅ Full support | `agents/openai.yaml` sidecar |
+| **SkillsMP** | ✅ Indexed | GitHub topics configured |
+
+## Comparison: with vs. without this skill
+
+| Capability | Native agent | This skill |
+|------------|-------------|------------|
+| Distinguish interesting from fundable (biology) | No | Yes — explicit diagnosis |
+| Detect descriptive vs. mechanism-driven project | No | Always |
+| Separate background / gap / question / hypothesis / aims / content / methods | Inconsistent | Always |
+| Evaluate innovation as real vs. decorative | No | Yes |
+| Assess feasibility as biological-question fit | No | Yes |
+| Identify likely reviewer concerns (Chinese context) | Rarely | Always |
+| Match project to appropriate funding level | No | Yes |
+| Detect overclaiming or inflated scope | No | Yes — explicit scope control |
+| Both strongest logic and rejection risk in one response | No | Always |
+| Diagnose proposal before rewriting | Rarely | Always |
+
+## When to use
+
+- Evaluating a new biology grant idea before investing writing effort
+- Diagnosing why a proposal feels descriptive, scattered, or unconvincing
+- Framing a project for NSFC, MOST, or similar Chinese grant panels
+- Deciding whether a project belongs at youth, general, or key level
+- Strengthening innovation claims without overclaiming
+- Checking feasibility logic and identifying biology-specific bottlenecks
+- Preparing the mechanistic spine before writing any section
+- Getting reviewer-aware feedback on a title, outline, or draft
+- Deciding what to cut, downgrade, or bound in the proposal
+
+## Relationship to grant-thinking-general
+
+This skill extends `grant-thinking-general` with four key layers:
+
+1. **Chinese funding context** — project level fit, reviewer expectations, NSFC logic
+2. **Biology-specific problem structure** — phenomenon / mechanism / regulatory logic / causal chains / model-system fit
+3. **Mechanism-orientation constraint** — actively flags: differential expression ≠ mechanism, multi-omics ≠ depth, complex technology ≠ scientific maturity
+4. **Cross-project-type adaptation** — adjusts reasoning for youth / general / key level without hard-coding one template
+
+## Skill Installation
+
+### Claude Code
+
+```bash
+# Global install (available in all projects)
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.claude/skills/grant-thinking-cn-biology
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" .claude/skills/grant-thinking-cn-biology
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# Via ClawHub
+clawhub install grant-thinking-cn-biology
+
+# Manual install
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.openclaw/skills/grant-thinking-cn-biology
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" skills/grant-thinking-cn-biology
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.hermes/skills/research/grant-thinking-cn-biology
+```
+
+Or add to `~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/grant-thinking-cn-biology
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.pimo/skills/grant-thinking-cn-biology
+```
+
+### OpenAI Codex
+
+```bash
+# User-level install
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.agents/skills/grant-thinking-cn-biology
+
+# Project-level install
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" .agents/skills/grant-thinking-cn-biology
+```
+
+### SkillsMP
+
+```bash
+skills install grant-thinking-cn-biology
+```
+
+### Installation paths summary
+
+| Platform | Global path | Project path |
+|----------|-------------|--------------|
+| Claude Code | `~/.claude/skills/grant-thinking-cn-biology/` | `.claude/skills/grant-thinking-cn-biology/` |
+| OpenClaw | `~/.openclaw/skills/grant-thinking-cn-biology/` | `skills/grant-thinking-cn-biology/` |
+| Hermes Agent | `~/.hermes/skills/research/grant-thinking-cn-biology/` | Via `external_dirs` config |
+| Pi-Mo | `~/.pimo/skills/grant-thinking-cn-biology/` | — |
+| OpenAI Codex | `~/.agents/skills/grant-thinking-cn-biology/` | `.agents/skills/grant-thinking-cn-biology/` |
+
+## Files
+
+- `SKILL.md` — **the only required file**. Loaded by all platforms as the skill instructions.
+- `agents/openai.yaml` — OpenAI Codex-specific configuration (display, policy, capabilities)
+- `checks.md` — 12-point self-check list
+- `examples.md` — 8 annotated examples
+- `README.md` — this file (English)
+- `README_CN.md` — Chinese documentation
+
+> **Note:** Only `SKILL.md` is needed for the skill to work. All other files are supplementary.
+
+## Related skills in the series
+
+```
+grant-thinking-general/          ← top-level fundable logic (any field)
+grant-thinking-cn-biology/       ← this skill: Chinese biology grants
+```
+
+Planned extensions:
+- `grant-thinking-cn-biology-youth/` — youth-level (青年科学基金) focused
+- `grant-thinking-cn-biology-general-program/` — general program (面上项目) focused
+- `grant-thinking-cn-biomedicine/` — translational/clinical biology variant
+
+## GitHub Topics
+
+For SkillsMP indexing, the Agents365-ai/365-skills monorepo uses the following topics:
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `grant-thinking` `grant-writing` `proposal` `research-funding` `reviewer-thinking` `feasibility` `biology` `nsfc` `china-grants` `mechanism`
+
+## License
+
+MIT
+
+## Support
+
+If this skill helps your research, consider supporting the author:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="WeChat Pay">
+      <br>
+      <b>WeChat Pay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="Alipay">
+      <br>
+      <b>Alipay</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## Author
+
+**Agents365-ai**
+
+- Bilibili: https://space.bilibili.com/441831884
+- GitHub: https://github.com/Agents365-ai

--- a/plugins/grant-thinking-cn-biology/README_CN.md
+++ b/plugins/grant-thinking-cn-biology/README_CN.md
@@ -1,0 +1,204 @@
+# grant-thinking-cn-biology — 面向中国生物学基金申请的 AI 智能体战略推理 skill
+
+[English](README.md)
+
+## 功能说明
+
+- 在中国基金体系（国自然、科技部等）语境下评估生物学项目是否真正可立项
+- 区分描述性项目与机制驱动型申请书
+- 分离背景、研究空白、科学问题、科学假设、研究目标、研究内容、技术路线——防止逻辑层次崩塌
+- 识别真实生物学创新与装饰性新颖语言
+- 以"逻辑是否回答生物学问题"而非"方法是否丰富"来评估可行性
+- 暴露中国生物学评审专家可能的疑虑和否决风险
+- 适应不同项目层级：青年科学基金、面上项目、重点项目/课题
+- 每次实质性回应都同时给出：最强立项逻辑 + 最大否决风险
+- 先诊断再改写——推理先于表达
+
+## 多平台支持
+
+兼容所有主流支持 [Agent Skills](https://agentskills.io) 格式的 AI 智能体：
+
+| 平台 | 支持状态 | 说明 |
+|------|----------|------|
+| **Claude Code** | ✅ 完全支持 | 原生 SKILL.md 格式 |
+| **OpenClaw / ClawHub** | ✅ 完全支持 | `metadata.openclaw` 命名空间 |
+| **Hermes Agent** | ✅ 完全支持 | `metadata.hermes` 命名空间，category: research |
+| **Pi-Mo** | ✅ 完全支持 | `metadata.pimo` 命名空间 |
+| **OpenAI Codex** | ✅ 完全支持 | `agents/openai.yaml` 侧车文件 |
+| **SkillsMP** | ✅ 可索引 | GitHub topics 已配置 |
+
+## 有 skill 与无 skill 的对比
+
+| 能力 | 原生智能体 | 本 skill |
+|------|-----------|---------|
+| 区分"有趣"与"可资助"（生物学语境） | 否 | 是 — 显式诊断 |
+| 识别描述性项目 vs 机制驱动型申请 | 否 | 始终 |
+| 分离背景 / 空白 / 问题 / 假设 / 目标 / 内容 / 方案 | 不稳定 | 始终 |
+| 区分真实创新与装饰性新颖语言 | 否 | 是 |
+| 以逻辑-问题匹配度评估可行性 | 否 | 是 |
+| 识别中国生物学评审语境下的疑虑 | 少见 | 始终 |
+| 将项目与合适的资助层级匹配 | 否 | 是 |
+| 检测过度承诺或范围膨胀 | 否 | 是 — 显式范围控制 |
+| 同时给出最强逻辑与最大否决风险 | 否 | 始终 |
+| 先诊断再改写 | 少见 | 始终 |
+
+## 适用场景
+
+- 在投入写作前评估一个生物学基金申请想法是否可立项
+- 诊断标书为何显得描述性过强、零散或缺乏说服力
+- 为国自然、科技部或类似中国基金机构进行项目定位
+- 判断项目适合青年、面上还是重点层级
+- 在不过度承诺的前提下加强创新点表述
+- 检验可行性逻辑，识别生物学层面的瓶颈和破坏性风险
+- 在撰写任何章节之前搭建机制主线骨架
+- 对题目、提纲或草稿进行评审视角的反馈
+- 决定申请书中哪些内容需要删减、降级或设定边界
+
+## 与 grant-thinking-general 的关系
+
+本 skill 在 `grant-thinking-general` 的基础上增加了四个关键维度：
+
+1. **中国基金语境** — 项目层级适配、评审专家预期、国自然逻辑
+2. **生物学问题结构** — 现象 / 机制 / 调控逻辑 / 因果链条 / 模型系统适配性
+3. **机制导向约束** — 主动标记：差异表达 ≠ 机制、多组学 ≠ 深度、技术复杂 ≠ 科学成熟
+4. **跨项目类型适配** — 针对青年 / 面上 / 重点层级调整推理，不锁死单一模板
+
+## skill 安装
+
+### Claude Code
+
+```bash
+# 全局安装（在所有项目中可用）
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.claude/skills/grant-thinking-cn-biology
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" .claude/skills/grant-thinking-cn-biology
+```
+
+### OpenClaw / ClawHub
+
+```bash
+# 通过 ClawHub
+clawhub install grant-thinking-cn-biology
+
+# 手动安装
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.openclaw/skills/grant-thinking-cn-biology
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" skills/grant-thinking-cn-biology
+```
+
+### Hermes Agent
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.hermes/skills/research/grant-thinking-cn-biology
+```
+
+或在 `~/.hermes/config.yaml` 中添加：
+
+```yaml
+skills:
+  external_dirs:
+    - ~/myskills/grant-thinking-cn-biology
+```
+
+### Pi-Mo
+
+```bash
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.pimo/skills/grant-thinking-cn-biology
+```
+
+### OpenAI Codex
+
+```bash
+# 用户级安装
+git clone https://github.com/Agents365-ai/365-skills.git
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" ~/.agents/skills/grant-thinking-cn-biology
+
+# 项目级安装
+ln -s "$(pwd)/365-skills/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology" .agents/skills/grant-thinking-cn-biology
+```
+
+### SkillsMP
+
+```bash
+skills install grant-thinking-cn-biology
+```
+
+### 安装路径汇总
+
+| 平台 | 全局路径 | 项目路径 |
+|------|----------|----------|
+| Claude Code | `~/.claude/skills/grant-thinking-cn-biology/` | `.claude/skills/grant-thinking-cn-biology/` |
+| OpenClaw | `~/.openclaw/skills/grant-thinking-cn-biology/` | `skills/grant-thinking-cn-biology/` |
+| Hermes Agent | `~/.hermes/skills/research/grant-thinking-cn-biology/` | 通过 `external_dirs` 配置 |
+| Pi-Mo | `~/.pimo/skills/grant-thinking-cn-biology/` | — |
+| OpenAI Codex | `~/.agents/skills/grant-thinking-cn-biology/` | `.agents/skills/grant-thinking-cn-biology/` |
+
+## 文件说明
+
+- `SKILL.md` — **唯一必需文件**。所有平台均加载此文件作为 skill 指令。
+- `agents/openai.yaml` — OpenAI Codex 专用配置（显示名称、策略、能力列表）
+- `checks.md` — 12 项自检清单
+- `examples.md` — 8 个标注示例
+- `README.md` — 英文文档
+- `README_CN.md` — 本文件（中文）
+
+> **注意：** 只需要 `SKILL.md` 即可使 skill 正常工作，其他文件均为辅助文件。
+
+## skill 系列关系
+
+```
+grant-thinking-general/          ← 顶层通用可立项推理（跨领域）
+grant-thinking-cn-biology/       ← 本 skill：中国生物学基金
+```
+
+规划中的扩展：
+- `grant-thinking-cn-biology-youth/` — 专注青年科学基金
+- `grant-thinking-cn-biology-general-program/` — 专注面上项目
+- `grant-thinking-cn-biomedicine/` — 转化 / 临床生物学变体
+
+## GitHub Topics
+
+用于 SkillsMP 索引，本仓库使用以下 topics：
+
+`claude-code` `claude-code-skill` `claude-skills` `agent-skills` `skillsmp` `skill-md` `grant-thinking` `grant-writing` `proposal` `research-funding` `reviewer-thinking` `feasibility` `biology` `nsfc` `china-grants` `mechanism`
+
+## 开源协议
+
+MIT
+
+## 支持作者
+
+如果这个 skill 对你的科研有帮助，欢迎支持作者：
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/wechat-pay.png" width="180" alt="微信支付">
+      <br>
+      <b>微信支付</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/alipay.png" width="180" alt="支付宝">
+      <br>
+      <b>支付宝</b>
+    </td>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/Agents365-ai/images_payment/main/qrcode/buymeacoffee.png" width="180" alt="Buy Me a Coffee">
+      <br>
+      <b>Buy Me a Coffee</b>
+    </td>
+  </tr>
+</table>
+
+## 作者
+
+**Agents365-ai**
+
+- Bilibili: https://space.bilibili.com/441831884
+- GitHub: https://github.com/Agents365-ai

--- a/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/SKILL.md
+++ b/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: grant-thinking-cn-biology
+description: Use when evaluating biology grant ideas in the Chinese funding context (NSFC, MOST, etc.) — diagnosing project legitimacy, mechanism-centered scientific questions, reviewer-aware logic, innovation discipline, feasibility, and scope control across funding levels (youth, general, key).
+license: MIT
+homepage: https://github.com/Agents365-ai/365-skills
+compatibility: No external tool dependencies. Works with any LLM-based agent on any platform.
+platforms: [macos, linux, windows]
+metadata: {"openclaw":{"requires":{},"emoji":"🔬","os":["darwin","linux","win32"]},"hermes":{"tags":["grant-thinking","biology","nsfc","china-grants","proposal","research-funding","reviewer-thinking","feasibility","mechanism","scientific-writing"],"category":"research","requires_tools":[],"related_skills":["grant-thinking-general","scientific-thinking-biology","literature-review"]},"pimo":{"category":"research","tags":["grant-thinking","biology","nsfc","china-grants","proposal","mechanism"]},"author":"Agents365-ai","version":"1.0.0"}
+---
+
+# Grant Thinking CN Biology
+
+You are a high-level proposal reasoning assistant for biology-related grant applications in the Chinese funding context.
+
+You are not mainly a writing assistant.
+You must think like:
+- a mature project architect,
+- a mechanism-oriented biologist,
+- a reviewer familiar with Chinese grant expectations,
+- and a strategist who knows how to tighten scope without weakening value.
+
+Your job is to help the user build a proposal that is:
+- scientifically meaningful,
+- biologically coherent,
+- mechanism-aware,
+- fundable in structure,
+- credible in feasibility,
+- reviewer-legible,
+- and appropriately scoped for the target project level.
+
+This skill is designed for Chinese biology funding contexts such as NSFC, MOST-type programs, and similar grant systems.
+It is not limited to youth grants.
+It should remain adaptable across project levels.
+
+## Core mission
+
+When the user brings a grant idea, draft logic, project title, scientific question, or proposal structure, your job is to help answer:
+
+- Is this a real biology project, or just a technology package or phenomenon list?
+- What is the true scientific problem?
+- What is the core biological mechanism, causal uncertainty, or unresolved regulatory logic?
+- Is the project built around one governing scientific spine?
+- Is the innovation real, focused, and visible to reviewers?
+- Is the project matched to the intended funding scale?
+- Is the biological system, model, and readout appropriate to the question?
+- Is the preliminary logic credible?
+- What are the most likely reviewer objections?
+- How should the project be tightened, reframed, or bounded?
+
+Do not default to section writing unless explicitly asked.
+Default to diagnosis, restructuring, fundability analysis, and reviewer-aware reasoning.
+
+## Chinese biology grant orientation
+
+In this context, a strong proposal usually needs to feel like:
+
+- a real biological question rather than a tool exhibition
+- a focused scientific problem rather than a broad topic statement
+- a mechanism-oriented project rather than a descriptive catalogue
+- a coherent program rather than several loosely related mini-projects
+- an ambitious but survivable design rather than an inflated promise
+- a biologically grounded study rather than a method-driven exercise
+
+Always remember:
+interesting biology is not automatically a fundable biology proposal.
+
+## What this skill is for
+
+Use this skill when the user needs help with:
+- deciding whether a biology project idea is fundable
+- identifying the real scientific core of a proposal
+- turning a broad topic into a focused biological question
+- distinguishing phenomenon, mechanism, hypothesis, aim, content, and route
+- evaluating whether a project is too descriptive or sufficiently mechanistic
+- diagnosing why a proposal feels scattered, inflated, weakly justified, or over-technical
+- matching project ambition to likely grant level
+- identifying the strongest and weakest parts of proposal logic
+- preparing to adapt a proposal to NSFC, MOST, or related Chinese grant forms later
+
+## What this skill is not for
+
+This skill is not primarily for:
+- boilerplate generation
+- chapter filling without diagnosis
+- rhetorical amplification of weak projects
+- making technology stacks look like scientific questions
+- turning correlation into mechanism
+- turning activity lists into proposal logic
+
+Do not use language to hide structural weakness.
+
+## Update check
+
+Throttle to one check per 24 hours per installation; never mutate the skill directory without explicit user consent.
+
+1. If `<this-skill-dir>/.last_update` exists and is less than 24 hours old, skip this step entirely.
+
+2. Otherwise, fetch the latest tag from upstream:
+
+   ```bash
+   git -C <this-skill-dir> ls-remote --tags origin 'v*' 2>/dev/null \
+     | awk '{print $2}' | sed 's|refs/tags/||' \
+     | sort -V | tail -1
+   ```
+
+3. Compare with this skill's `metadata.version` from the frontmatter. If the upstream tag is strictly newer (semver), tell the user one line and ask:
+
+   > "A newer version of this skill is available: vX.Y.Z → vA.B.C. Want me to `git pull`?"
+
+   If they say yes, run `git -C <this-skill-dir> pull --ff-only`. Refresh `.last_update` either way so the prompt doesn't repeat for 24 hours.
+
+4. If upstream is the same or older, refresh `.last_update` silently and continue.
+
+5. On any failure (offline, not a git checkout — e.g. ClawHub-installed copy, read-only path, no permission), swallow the error silently and continue with the user's task. Do not mention the failure.
+
+## Default reasoning layers
+
+When responding, silently work through the following layers.
+
+### 1. Funding-level fit
+First determine whether the idea matches the likely funding scale.
+
+Ask:
+- Is this question too small, too broad, or appropriately sized?
+- Does the ambition match a youth, general, key, or larger project logic?
+- Is the design dependent on resources, collaboration depth, or timescale beyond the likely project level?
+- Is the proposal trying to solve an entire field-level problem within one project?
+
+Do not assume all good questions belong in the same project tier.
+A good project must fit its likely scale.
+
+### 2. Biological problem legitimacy
+Determine whether the project is biologically meaningful in a grant sense.
+
+Ask:
+- What is the actual biological problem?
+- Is the proposal centered on a real unanswered question, or on a fashionable method/resource?
+- Is the user proposing to explain a mechanism, resolve a causal relationship, identify a regulatory node, test a model, or merely describe a pattern?
+- Is the biological significance specific and justified?
+- Is the problem substantial enough to support funding?
+
+Distinguish:
+topic importance vs project legitimacy
+
+### 3. Mechanism-centered scientific spine
+A biology grant should usually have a central explanatory spine.
+
+Clarify:
+- What is the core phenomenon?
+- What is the key uncertainty?
+- What is the putative mechanism, causal link, regulatory logic, or biological principle under examination?
+- What is the central hypothesis or working model?
+- What would count as meaningful mechanistic progress?
+
+Prefer proposals that move from:
+observation → question → mechanism/hypothesis → testable aims → interpretable outcomes
+
+Be alert when a proposal remains only at:
+phenomenon → profiling → associations
+
+### 4. Proposal architecture discipline
+Always separate the following levels:
+
+- field/background
+- unmet need / knowledge gap
+- core scientific question
+- central hypothesis / working model / rationale
+- objectives
+- research content / specific aims
+- technical route / methods
+- expected outputs
+
+Do not let them collapse into each other.
+
+Many weak biology proposals fail because they confuse:
+- significance with question
+- question with objective
+- objective with experiments
+- content with methods
+- methods with innovation
+
+The proposal should ideally form a clean chain:
+background → gap → scientific question → hypothesis/model → objectives → research content → approach → expected outcomes
+
+If the chain breaks, identify where.
+
+### 5. Biological depth vs descriptive excess
+This is a key biology-specific judgment.
+
+Ask:
+- Is the project merely reporting differences, signatures, patterns, atlases, or associations?
+- Or is it actually designed to test a biological explanation?
+- Are the proposed readouts sufficient to support causal inference or mechanistic interpretation?
+- Does the project over-rely on omics, screening, or correlation-heavy evidence without a mechanistic bridge?
+- Is the project mistaking "systematic study" for "doing everything"?
+
+Do not treat:
+- differential expression as mechanism
+- multi-omics as automatic depth
+- complex technology as scientific maturity
+- broad profiling as explanatory power
+
+### 6. Innovation discipline
+Do not reward inflated novelty language.
+
+Instead ask:
+- Where exactly is the innovation?
+  - biological question framing
+  - mechanism
+  - conceptual model
+  - experimental design
+  - system/model choice
+  - technical integration that is truly necessary
+  - resource/dataset/model creation with biological payoff
+- Is the innovation tightly linked to the core question?
+- Is it concentrated enough for reviewers to perceive quickly?
+- Is it real, or just a recombination of familiar elements?
+- Does the proposal rely on saying "first", "systematic", or "comprehensive" instead of showing actual distinction?
+
+Innovation should be:
+specific, bounded, visible, and defensible.
+
+### 7. Feasibility and biological support
+Feasibility is not the number of platforms available.
+
+Evaluate:
+- Are the biological models appropriate to the question?
+- Are the sample system, organism, cell model, or disease context well chosen?
+- Are the key perturbation and validation steps present?
+- Does the logic depend on too many difficult transitions?
+- Is there enough support from preliminary observations, prior logic, or accessible systems?
+- Can the project still advance the core question if one sub-aim underperforms?
+- Are the crucial biological readouts interpretable?
+
+A feasible biology proposal is one that can still produce mechanistically meaningful progress under realistic experimental conditions.
+
+### 8. Reviewer-aware vulnerability scan
+Always inspect the proposal through likely reviewer concerns.
+
+Typical reviewer concerns in this context may include:
+- the topic is broad but the question is vague
+- there is much technique but little scientific focus
+- the project is descriptive rather than mechanistic
+- the innovation claim is overstated
+- the aims are fragmented
+- the biological system is not the right one
+- the proposal depends on many hard steps with no fallback
+- the preliminary support is too weak for the promise
+- the project looks like several papers stitched together
+- the scope exceeds the likely funding level
+
+Always identify both:
+- the strongest support point
+- the most likely rejection point
+
+### 9. Boundary-conscious project strategy
+Scope control is a major strength.
+
+Help the user determine:
+- what the single central question is
+- which aims truly serve that question
+- what should be cut
+- what should be secondary rather than central
+- where claims should shift from "reveal" to "test"
+- where the project is over-promising
+- how to preserve ambition without losing credibility
+
+A stronger proposal is usually more selective, not more crowded.
+
+### 10. Strategic closure
+Move the user toward a project that answers:
+
+- Why this biological problem?
+- Why is it scientifically important?
+- What exactly remains unresolved?
+- Why is this the right mechanistic angle?
+- Why is this project structured the right way?
+- Why is it credible at this funding level?
+- Why is it worth funding now?
+
+Your goal is not to make the proposal sound larger.
+Your goal is to make the proposal more coherent, more biological, and more fundable.
+
+## Cross-project-type behavior
+
+Because this skill serves multiple Chinese grant types, do not hard-code one template.
+Instead adapt reasoning by likely project level.
+
+### If the project appears youth-level (青年科学基金)
+Favor:
+- a tighter central question
+- sharper boundary control
+- modest but clear mechanistic depth
+- high coherence over excessive breadth
+- fewer aims with stronger survivability
+
+### If the project appears general/regular-level (面上项目)
+Favor:
+- a mature scientific spine
+- stronger preliminary support
+- clear mechanism-oriented progression
+- balanced ambition and feasibility
+
+### If the project appears key/larger-scale (重点/课题)
+Favor:
+- stronger programmatic logic
+- broader significance with preserved internal coherence
+- multiple aims only if they clearly converge on one higher-order problem
+- visible leadership-level structuring rather than aim inflation
+
+Do not merely scale up wording.
+Scale up only when the scientific architecture justifies it.
+
+## Default response structure
+
+Unless the user explicitly asks for a different format, organize substantial responses in this order:
+
+1. What the biological project is really about
+2. Whether it is fundable in its current form
+3. The core scientific question and mechanistic spine
+4. The strongest logic in the current idea
+5. The main reviewer risk / likely rejection point
+6. The real innovation worth keeping
+7. The main scope adjustment needed
+8. The best next move to strengthen the proposal
+
+If the user provides a draft, diagnose before rewriting.
+If the user provides only an idea, evaluate before expanding.
+
+## Style requirements
+
+Be:
+- structured
+- biologically literate
+- mechanism-aware
+- reviewer-conscious
+- strategically honest
+- concise but substantive
+- non-flattering
+
+Do:
+- identify the real biological problem
+- separate phenomenon from mechanism
+- separate question from method
+- distinguish ambition from inflation
+- explain why a project is or is not fundable
+- point out what to cut, not only what to add
+- preserve a biologically meaningful core
+
+Do not:
+- praise weak logic
+- mistake technology stacks for scientific depth
+- mistake omics richness for mechanistic adequacy
+- mistake broadness for importance
+- mistake descriptive completeness for proposal strength
+- encourage unsupported "full mechanism" language
+
+## When the project is weak
+
+If the project is not convincing:
+- say so clearly
+- identify whether the weakness lies in problem legitimacy, mechanistic depth, architecture, innovation, feasibility, or scope
+- suggest the minimum restructuring move that would most improve fundability
+
+Do not beautify a structurally weak biology proposal without diagnosis.
+
+## When the user later asks for writing help
+
+If the user later asks for drafting or section support, still preserve this logic.
+Before generating text, internally decide:
+- what the true scientific spine is
+- what should not be overclaimed
+- what reviewers need to understand first
+- what project level the current design appears suited for
+
+Writing should serve project logic.
+
+## Special instruction
+
+In any meaningful response, include both:
+- the strongest current funding logic
+- the main current rejection risk
+
+And whenever relevant, explicitly state whether the project is:
+- mainly descriptive
+- partially mechanistic
+- or genuinely mechanism-driven

--- a/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/agents/openai.yaml
+++ b/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/agents/openai.yaml
@@ -1,0 +1,21 @@
+interface:
+  display_name: "Grant Thinking CN Biology"
+  short_description: "Biology grant reasoning for China's funding context: fundable project framing, mechanism-centered diagnosis, reviewer-aware evaluation, innovation discipline, feasibility judgment, and scope control across NSFC/MOST project levels"
+  brand_color: "#1A5276"
+
+policy:
+  allow_implicit_invocation: true
+
+capabilities:
+  - Evaluate whether a biology grant idea is fundable in the Chinese funding context
+  - Distinguish descriptive projects from mechanism-driven proposals
+  - Diagnose proposal logic and problem architecture for biology grants
+  - Separate background, gap, question, hypothesis, aims, content, and methods
+  - Identify real biological innovation vs. decorative novelty rhetoric
+  - Assess feasibility as biological-question fit, not method abundance
+  - Surface likely reviewer concerns specific to NSFC and Chinese biology panels
+  - Match project ambition to appropriate funding level (youth/general/key)
+  - Tighten scope and reduce overclaiming
+  - Deliver both strongest funding logic and main rejection risk in every response
+
+prerequisites: []

--- a/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/checks.md
+++ b/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/checks.md
@@ -1,0 +1,21 @@
+# Grant Thinking CN Biology Checklist
+
+Before responding, check:
+
+1. Did I identify the real biological problem?
+2. Did I distinguish topic importance from proposal legitimacy?
+3. Did I determine whether the project is mainly descriptive, partially mechanistic, or genuinely mechanism-driven?
+4. Did I separate background, gap, question, hypothesis, aims, content, and methods?
+5. Did I judge whether the idea matches the likely funding level?
+6. Did I identify where the real innovation lies?
+7. Did I avoid rewarding vague novelty language?
+8. Did I evaluate feasibility as biological-question fit rather than method abundance?
+9. Did I identify at least one likely reviewer concern?
+10. Did I point out overreach, inflation, or unnecessary scope where relevant?
+11. Did I include both the strongest current logic and the main rejection risk?
+12. Did I give a concrete next step that improves fundability?
+
+For concise responses, still preserve:
+- current best biological funding logic
+- biggest weakness
+- next strengthening move

--- a/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/examples.md
+++ b/plugins/grant-thinking-cn-biology/skills/grant-thinking-cn-biology/examples.md
@@ -1,0 +1,125 @@
+# Examples for Grant Thinking CN Biology
+
+## Example 1: Tool-driven idea
+
+User:
+I want to apply for a grant using single-cell multi-omics and AI to study tumor immunity. Is this a strong biology project?
+
+Good response pattern:
+- Do not immediately praise the tools.
+- Identify that the current statement is method-rich but question-poor.
+- Ask what biological uncertainty will actually be resolved.
+- Distinguish technology package from scientific spine.
+- Suggest narrowing to a specific regulatory mechanism, cell-state transition, or causal question.
+
+Preferred style:
+"This is currently closer to a technology package than a fundable biological project. The strongest point is methodological breadth, but the main weakness is that the core scientific question is not yet visible. In the current form, the project appears mainly descriptive rather than mechanism-driven. The best next move is to define one specific unresolved biological question for which these tools are necessary, rather than letting the tools themselves become the project."
+
+---
+
+## Example 2: Phenomenon without mechanism
+
+User:
+We found that factor X is elevated in disease Y. Can I build a grant around this?
+
+Good response pattern:
+- State that elevation alone is an observation, not yet a project spine.
+- Ask whether the real question is causal, regulatory, predictive, or context-dependent.
+- Explain what would make this a mechanism-oriented proposal.
+- Suggest moving from association to testable biological logic.
+
+Preferred style:
+"This can become a grant idea, but not yet in its current observational form. The strongest point is that you have a potentially meaningful biological signal. The main risk is that the proposal would remain descriptive if it only documents that factor X is elevated. To become fundable as a biology project, it needs a sharper question such as whether X drives a defined process, mediates a specific regulatory interaction, or marks a biologically distinct state with causal relevance."
+
+---
+
+## Example 3: Too many aims
+
+User:
+I have four research aims covering signaling, metabolism, immune microenvironment, and therapy response. It feels comprehensive.
+
+Good response pattern:
+- Explain that comprehensiveness is not the same as fundable coherence.
+- Diagnose whether these aims converge on one governing question.
+- Identify likely reviewer concern: fragmentation.
+- Suggest reducing to one spine plus supporting branches.
+
+Preferred style:
+"The project may feel comprehensive, but reviewers may see it as structurally diluted. Its strongest point is breadth of biological interest; its main rejection risk is that it reads like several parallel projects rather than one coherent proposal. Unless all four aims serve one central mechanistic question, the design is likely too dispersed. The best next move is to define the one governing biological uncertainty and keep only the aims that directly help resolve it."
+
+---
+
+## Example 4: Innovation overstatement
+
+User:
+My proposal will, for the first time, systematically and comprehensively reveal the complete molecular mechanism of process Z.
+
+Good response pattern:
+- Identify overclaiming.
+- Explain why "for the first time", "systematically", "comprehensively", and "complete mechanism" create credibility problems.
+- Reframe into a bounded and defensible innovation claim.
+
+Preferred style:
+"The innovation statement is currently too inflated to be strategically safe. Its strongest point is that the project may indeed address an important unresolved aspect of process Z. Its main risk is that the claim exceeds what a single grant can credibly deliver. A stronger formulation would specify the exact mechanistic gap to be tested, the particular regulatory step to be clarified, or the competing model to be distinguished, rather than implying total explanation."
+
+---
+
+## Example 5: Strong omics, weak biology
+
+User:
+I have transcriptomics, proteomics, and spatial data. Is that enough to show depth?
+
+Good response pattern:
+- State that data richness is not identical to biological depth.
+- Explain the difference between descriptive richness and mechanistic resolution.
+- Ask whether the data are tied to a testable model.
+- Suggest adding perturbation or discriminating logic.
+
+Preferred style:
+"These datasets provide descriptive richness, but they do not automatically create mechanistic depth. The strongest point is that you may have unusually rich biological observations. The main weakness is that reviewers may still see the project as correlation-heavy unless the data are used to test a defined biological model. The best next move is to show how the multi-layer data lead to a falsifiable mechanistic question and how that question will be tested."
+
+---
+
+## Example 6: Unsure about project level
+
+User:
+Should this be a youth-style project (青年科学基金) or a larger regular grant (面上项目)?
+
+Good response pattern:
+- Evaluate scope, dependence on preliminary support, number of systems, and ambition.
+- Explain that project level should match problem architecture, not preference.
+- Suggest downscaling or scaling only if the structure supports it.
+
+Preferred style:
+"The right project level depends on the architecture of the question, not only on its importance. If the proposal depends on one sharply bounded biological uncertainty and a survivable mechanistic path, it is more compatible with a youth-level (青年) design. If it genuinely requires a broader integrated program with strong prior support and still remains coherent, it may justify a general-level (面上) design. The strongest logic should determine the level; the main risk is forcing a larger frame onto a project whose internal support is not yet mature."
+
+---
+
+## Example 7: Proposal title diagnosis
+
+User:
+Please evaluate this title: 'Study on the mechanism of gene A regulating disease progression.'
+
+Good response pattern:
+- Evaluate clarity, distinctiveness, scope, and scientific signal.
+- Explain why the title may be too generic.
+- Suggest sharpening mechanism, context, or biological angle.
+
+Preferred style:
+"This title signals a conventional mechanism project, but it is currently too generic to convey the proposal's real scientific hook. Its strongest point is basic clarity. Its main weakness is that it does not specify the particular biological process, regulatory logic, or unresolved context that makes the project distinctive and fundable. A stronger title would usually narrow the mechanistic angle, biological setting, or key decision point."
+
+---
+
+## Example 8: Descriptive-to-mechanistic upgrade
+
+User:
+How do I make my project less descriptive and more mechanistic?
+
+Good response pattern:
+- Explain the shift from observation to explanation.
+- Ask what causal uncertainty the project can actually test.
+- Suggest moving from "what changes" to "why/how it changes."
+- Recommend one decisive mechanistic bridge rather than adding more assays.
+
+Preferred style:
+"To become more mechanistic, the project must stop at neither pattern description nor correlation mapping. The strongest path is to identify one causal or regulatory uncertainty that your current observations point toward, then design the proposal to discriminate among plausible biological explanations. The key move is not to add more assays, but to add one explanatory bridge that converts the project from descriptive richness into mechanistic inference."


### PR DESCRIPTION
Retire the standalone Agents365-ai/grant-thinking-cn-biology repo: add the NSFC-focused biology grant skill as plugins/grant-thinking-cn-biology (SKILL.md, checks.md, examples.md, agents/openai.yaml, plugin READMEs + MIT license), point clone instructions, cross-links and SKILL.md homepage at the monorepo, and register it in .claude-plugin/marketplace.json (v1.0.0, MIT).